### PR TITLE
Partial update of a Zotero library

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pre-commit
+requests-mock

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
             "plone.testing>=5.0.0",
             "plone.app.contenttypes",
             "plone.app.robotframework[debug]",
+            "requests-mock",
         ],
         "celery": ["collective.celery"],
     },

--- a/src/jazkarta/zoterolib/browser/views.py
+++ b/src/jazkarta/zoterolib/browser/views.py
@@ -138,10 +138,15 @@ class UpdateLibraryForm(z3c.form.form.Form):
                 batch_size=self.batch_size,
                 stop_at_date=stop_at_date,
             )
-            self.status = _(
-                u"Started updating Zotero Library. Updates since %s will be fetched. You will recieve an email when indexing is completed."
-                % stop_at_date
-            )
+            if not stop_at_date:
+                self.status = _(
+                    u"Started updating Zotero Library. Updates since %s will be fetched. You will recieve an email when indexing is completed."
+                    % stop_at_date
+                )
+            else:
+                self.status = _(
+                    u"Started updating Zotero Library. All items be fetched. You will recieve an email when indexing is completed."
+                )
         else:
             start_time = time.time()
             count = self.context.update_items()

--- a/src/jazkarta/zoterolib/browser/views.py
+++ b/src/jazkarta/zoterolib/browser/views.py
@@ -138,7 +138,7 @@ class UpdateLibraryForm(z3c.form.form.Form):
                 batch_size=self.batch_size,
                 stop_at_date=stop_at_date,
             )
-            if not stop_at_date:
+            if stop_at_date:
                 self.status = _(
                     u"Started updating Zotero Library. Updates since %s will be fetched. You will recieve an email when indexing is completed."
                     % stop_at_date

--- a/src/jazkarta/zoterolib/content/zotero_library.py
+++ b/src/jazkarta/zoterolib/content/zotero_library.py
@@ -115,13 +115,20 @@ class ZoteroLibrary(Item):
             else:
                 current_batch = []
 
+    def get_most_recent_obj_date(self):
+        """Return a string representing the most recent modification date of an object in this library."""
+        catalog = getToolByName(self, "portal_catalog")
+        most_recent_objs = catalog.searchResults(
+            sort_on='modified', portal_type="ExternalZoteroItem"
+        )
+        if most_recent_objs:
+            most_recent_obj = most_recent_objs[-1]
+            return most_recent_obj.modified.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return ""
+
     def update_items(self, start=0, limit=100):
         """Update all items in the catalog fetching only items that have been modified since the last update."""
-        catalog = getToolByName(self, "portal_catalog")
-        most_recent_obj = catalog.searchResults(
-            sort_on='modified', portal_type="ExternalZoteroItem"
-        )[-1]
-        most_recent_date = most_recent_obj.modified.strftime("%Y-%m-%dT%H:%M:%SZ")
+        most_recent_date = self.get_most_recent_obj_date()
         count = 0
         for item in self.fetch_items(start, limit):
             if item["data"]["dateModified"] < most_recent_date:

--- a/src/jazkarta/zoterolib/content/zotero_library.py
+++ b/src/jazkarta/zoterolib/content/zotero_library.py
@@ -119,13 +119,15 @@ class ZoteroLibrary(Item):
         """Return a string representing the most recent modification date of an object in this library."""
         catalog = getToolByName(self, "portal_catalog")
         most_recent_objs = catalog.searchResults(
-            sort_on='modified',
             portal_type="ExternalZoteroItem",
             path='/'.join(self.getPhysicalPath()),
+            sort_on='modified',
+            sort_order='descending',
+            sort_limit=1,
         )
         if most_recent_objs:
-            most_recent_obj = most_recent_objs[-1]
-            return most_recent_obj.modified.strftime("%Y-%m-%dT%H:%M:%SZ")
+            most_recent_obj = most_recent_objs[0]
+            return most_recent_obj.modified.HTML4()
         return ""
 
     def update_items(self, start=0, limit=100):

--- a/src/jazkarta/zoterolib/content/zotero_library.py
+++ b/src/jazkarta/zoterolib/content/zotero_library.py
@@ -119,7 +119,9 @@ class ZoteroLibrary(Item):
         """Return a string representing the most recent modification date of an object in this library."""
         catalog = getToolByName(self, "portal_catalog")
         most_recent_objs = catalog.searchResults(
-            sort_on='modified', portal_type="ExternalZoteroItem"
+            sort_on='modified',
+            portal_type="ExternalZoteroItem",
+            path='/'.join(self.getPhysicalPath()),
         )
         if most_recent_objs:
             most_recent_obj = most_recent_objs[-1]

--- a/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.headers.json
+++ b/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.headers.json
@@ -1,0 +1,15 @@
+{
+  "Zotero-Schema-Version": "15",
+  "Last-Modified-Version": "608",
+  "Keep-Alive": "timeout=5, max=100",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Vary": "Accept-Encoding",
+  "Content-Length": "36937",
+  "Server": "Apache/2.4.53 ()",
+  "Connection": "Keep-Alive",
+  "Link": "<https://api.zotero.org/groups/242005/items?include=bib%2Ccitation%2Cdata&limit=100&style=modern-language-association>; rel=\"first\", <https://api.zotero.org/groups/242005/items?include=bib%2Ccitation%2Cdata&limit=100&style=modern-language-association>; rel=\"prev\", <https://www.zotero.org/groups/242005/items>; rel=\"alternate\"",
+  "Date": "Wed, 15 Jun 2022 19:41:24 GMT",
+  "Total-Results": "180",
+  "Zotero-API-Version": "3",
+  "Content-Type": "application/json"
+}

--- a/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.txt
+++ b/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.txt
@@ -1,0 +1,8243 @@
+[
+    {
+        "key": "EJBWY9PM",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/EJBWY9PM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/EJBWY9PM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Baumann",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Baumann, Ryan. &#x201C;Linked Open Data for Papyrology.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 11, 2021, http://hdl.handle.net/2333.1/2jm647v1.</div>\n</div>",
+        "citation": "<span>(Baumann)</span>",
+        "data": {
+            "key": "EJBWY9PM",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for Papyrology",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ryan",
+                    "lastName": "Baumann"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "11",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/2jm647v1",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:06:13Z",
+            "dateModified": "2021-12-11T11:49:35Z"
+        }
+    },
+    {
+        "key": "2F9S294R",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/2F9S294R",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/2F9S294R",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Archibald et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Archibald, Zosia, et al. &#x201C;Archaeology in Greece 2014&#x2013;2015.&#x201D; <i>Archaeological Reports</i>, no. 61, 2014, pp. 1&#x2013;135, https://doi.org/10/gf5vkn.</div>\n</div>",
+        "citation": "<span>(Archibald et al.)</span>",
+        "data": {
+            "key": "2F9S294R",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Archaeology in Greece 2014–2015",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Zosia",
+                    "lastName": "Archibald"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Catherine",
+                    "lastName": "Morgan"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "David Michael",
+                    "lastName": "Smith"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Robert K.",
+                    "lastName": "Pitt"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Chryssanthi",
+                    "lastName": "Papadopoulou"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Fabienne",
+                    "lastName": "Marchand"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "J.",
+                    "lastName": "Fournier"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "P.",
+                    "lastName": "Hamon"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "M.G.",
+                    "lastName": "Parissaki"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Matthew",
+                    "lastName": "Haysom"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Olga",
+                    "lastName": "Palagia"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Mantha",
+                    "lastName": "Zarmakoupi"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Archaeological Reports",
+            "volume": "",
+            "issue": "61",
+            "pages": "1-135",
+            "date": "2014",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gf5vkn",
+            "ISSN": "0570-6084",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/24877885",
+            "accessDate": "2021-04-15T15:33:24Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: [The Society for the Promotion of Hellenic Studies, Cambridge University Press]",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HQSVSTD9"
+            },
+            "dateAdded": "2021-04-15T15:33:24Z",
+            "dateModified": "2021-12-11T11:49:34Z"
+        }
+    },
+    {
+        "key": "6TVWMWES",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6TVWMWES",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6TVWMWES",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Gupta and Devillers",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Gupta, Neha, and Rodolphe Devillers. &#x201C;Geographic Visualization in Archaeology.&#x201D; <i>Journal of Archaeological Method and Theory</i>, vol. 24, no. 3, 2017, pp. 852&#x2013;85, https://doi.org/10/gd6b6z.</div>\n</div>",
+        "citation": "<span>(Gupta and Devillers)</span>",
+        "data": {
+            "key": "6TVWMWES",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Geographic Visualization in Archaeology",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Neha",
+                    "lastName": "Gupta"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Rodolphe",
+                    "lastName": "Devillers"
+                }
+            ],
+            "abstractNote": "Archaeologists are often considered frontrunners in employing spatial approaches within the social sciences and humanities, including geospatial technologies such as geographic information systems (GIS) that are now routinely used in archaeology. Since the late 1980s, GIS has mainly been used to support data collection and management as well as spatial analysis and modeling. While fruitful, these efforts have arguably neglected the potential contribution of advanced visualization methods to the generation of broader archaeological knowledge. This paper reviews the use of GIS in archaeology from a geographic visualization (geovisual) perspective and examines how these methods can broaden the scope of archaeological research in an era of more user-friendly cyber-infrastructures. Like most computational databases, GIS do not easily support temporal data. This limitation is particularly problematic in archaeology because processes and events are best understood in space and time. To deal with such shortcomings in existing tools, archaeologists often end up having to reduce the diversity and complexity of archaeological phenomena. Recent developments in geographic visualization begin to address some of these issues and are pertinent in the globalized world as archaeologists amass vast new bodies of georeferenced information and work towards integrating them with traditional archaeological data. Greater effort in developing geovisualization and geovisual analytics appropriate for archaeological data can create opportunities to visualize, navigate, and assess different sources of information within the larger archaeological community, thus enhancing possibilities for collaborative research and new forms of critical inquiry.",
+            "publicationTitle": "Journal of Archaeological Method and Theory",
+            "volume": "24",
+            "issue": "3",
+            "pages": "852-885",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gd6b6z",
+            "ISSN": "1072-5369",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/26748344",
+            "accessDate": "2021-04-15T15:36:47Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Springer",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:36:47Z",
+            "dateModified": "2021-12-11T11:49:33Z"
+        }
+    },
+    {
+        "key": "SUXEQCQ5",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/SUXEQCQ5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/SUXEQCQ5",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Lucarelli",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lucarelli, Rita. &#x201C;The Magician as a Literary Figure in Ancient Egyptian Texts.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 3, 2020, http://hdl.handle.net/2333.1/s4mw6x82.</div>\n</div>",
+        "citation": "<span>(Lucarelli)</span>",
+        "data": {
+            "key": "SUXEQCQ5",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "The Magician as a Literary Figure in Ancient Egyptian Texts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rita",
+                    "lastName": "Lucarelli"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "3",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/s4mw6x82",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:51:19Z",
+            "dateModified": "2021-12-11T11:49:33Z"
+        }
+    },
+    {
+        "key": "LJ62XZGH",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/LJ62XZGH",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/LJ62XZGH",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Konstantopoulos",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Konstantopoulos, Gina. &#x201C;Looking for Glinda: Wise Women and Benevolent Magic in Old Babylonian Literary Texts.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 2, 2020, http://hdl.handle.net/2333.1/wwpzgxs5.</div>\n</div>",
+        "citation": "<span>(Konstantopoulos)</span>",
+        "data": {
+            "key": "LJ62XZGH",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Looking for Glinda: Wise Women and Benevolent Magic in Old Babylonian Literary Texts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Gina",
+                    "lastName": "Konstantopoulos"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "2",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/wwpzgxs5",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/ZDM7D5M6"
+            },
+            "dateAdded": "2021-04-15T15:48:06Z",
+            "dateModified": "2021-12-11T11:49:32Z"
+        }
+    },
+    {
+        "key": "VW4CDVB6",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VW4CDVB6",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VW4CDVB6",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Matthey",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Matthey, Philippe. &#x201C;From Cult Practice to Magical Ritual: Deciphering the &#x2018;Lecanomancy&#x2019; in the Alexander Romance.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 7, 2020, http://hdl.handle.net/2333.1/866t1rxv.</div>\n</div>",
+        "citation": "<span>(Matthey)</span>",
+        "data": {
+            "key": "VW4CDVB6",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "From Cult Practice to Magical Ritual: Deciphering the “Lecanomancy” in the Alexander Romance",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Philippe",
+                    "lastName": "Matthey"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "7",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/866t1rxv",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:07:08Z",
+            "dateModified": "2021-12-11T11:49:32Z"
+        }
+    },
+    {
+        "key": "EG3IWB5P",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/EG3IWB5P",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/EG3IWB5P",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hawthorn",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hawthorn, Ainsley. &#x201C;The Fish and the Tamarisk: Sexual and Celestial Symbolism in &#x2018;Lugalbanda and the Anzu Bird.&#x2019;&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 4, 2020, http://hdl.handle.net/2333.1/ncjsxwqb.</div>\n</div>",
+        "citation": "<span>(Hawthorn)</span>",
+        "data": {
+            "key": "EG3IWB5P",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "The Fish and the Tamarisk: Sexual and Celestial Symbolism in “Lugalbanda and the Anzu Bird”",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ainsley",
+                    "lastName": "Hawthorn"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "4",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/ncjsxwqb",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:00:10Z",
+            "dateModified": "2021-12-11T11:49:31Z"
+        }
+    },
+    {
+        "key": "HQSVSTD9",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/HQSVSTD9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/HQSVSTD9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Zarmakoupi",
+            "parsedDate": "2013",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Zarmakoupi, Mantha. &#x201C;The Quartier Du Stade on Late Hellenistic Delos: A Case Study of Rapid Urbanization (Fieldwork Seasons 2009-2010).&#x201D; <i>ISAW Papers</i>, vol. 6, 2013, http://hdl.handle.net/2333.1/51c5b1dw.</div>\n</div>",
+        "citation": "<span>(Zarmakoupi)</span>",
+        "data": {
+            "key": "HQSVSTD9",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "The Quartier du Stade on late Hellenistic Delos: a case study of rapid urbanization (fieldwork seasons 2009-2010)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Mantha",
+                    "lastName": "Zarmakoupi"
+                }
+            ],
+            "abstractNote": "This study examines recent archaeological evidence for the Quartier du Stade on Delos, which was newly formed after 167 CE. Analysis of the changes in the houses and the overall urban development of this neighborhood contribute to revealing the forces that shaped the city of Delos in this period, such as economy, politics, ideology.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "6",
+            "issue": "",
+            "pages": "",
+            "date": "2013",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/51c5b1dw",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/2F9S294R",
+                    "http://zotero.org/groups/242005/items/6ZIG94CD"
+                ]
+            },
+            "dateAdded": "2014-01-15T15:27:21Z",
+            "dateModified": "2021-12-11T11:49:31Z"
+        }
+    },
+    {
+        "key": "B6PNCEZE",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/B6PNCEZE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/B6PNCEZE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Roblee",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Roblee, Mark. &#x201C;Divination Is Divinization: The Ancient Egyptian P&#x1E25;-N&#x1E6F;r Oracle and the &#x2018;Mithras Liturgy&#x2019; in Late Roman Egypt.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 6, 2020, http://hdl.handle.net/2333.1/cz8w9sdx.</div>\n</div>",
+        "citation": "<span>(Roblee)</span>",
+        "data": {
+            "key": "B6PNCEZE",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Divination is Divinization: The ancient Egyptian pḥ-nṯr oracle and the “Mithras Liturgy” in Late Roman Egypt",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Mark",
+                    "lastName": "Roblee"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "6",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/cz8w9sdx",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:06:02Z",
+            "dateModified": "2021-12-11T11:49:30Z"
+        }
+    },
+    {
+        "key": "HVJL638I",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/HVJL638I",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/HVJL638I",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Naether",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Naether, Franziska. &#x201C;Introduction.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 1, 2020, http://hdl.handle.net/2333.1/1ns1rz35.</div>\n</div>",
+        "citation": "<span>(Naether)</span>",
+        "data": {
+            "key": "HVJL638I",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Introduction",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "1",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/1ns1rz35",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:46:33Z",
+            "dateModified": "2021-12-11T11:49:30Z"
+        }
+    },
+    {
+        "key": "ZBIVT2MS",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZBIVT2MS",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZBIVT2MS",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Livingston",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Livingston, Lucas. &#x201C;Alcohol&#x2019;s Magic in Antiquity: Fermentation, Intoxication, Metamorphosis, and Madness.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 10, 2020, http://hdl.handle.net/2333.1/vx0k6qj9.</div>\n</div>",
+        "citation": "<span>(Livingston)</span>",
+        "data": {
+            "key": "ZBIVT2MS",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Alcohol's Magic in Antiquity: Fermentation, Intoxication, Metamorphosis, and Madness",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Lucas",
+                    "lastName": "Livingston"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "10",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/vx0k6qj9",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:08:22Z",
+            "dateModified": "2021-12-11T11:49:30Z"
+        }
+    },
+    {
+        "key": "ISE8RS9C",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ISE8RS9C",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ISE8RS9C",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Chepel",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Chepel, Elena. &#x201C;Alternative Facts from Oracles and Post-Truth Politics in Aristophanes.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 9, 2020, http://hdl.handle.net/2333.1/0p2ngqxg.</div>\n</div>",
+        "citation": "<span>(Chepel)</span>",
+        "data": {
+            "key": "ISE8RS9C",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Alternative Facts from Oracles and Post-Truth Politics in Aristophanes",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Elena",
+                    "lastName": "Chepel"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "9",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/0p2ngqxg",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:12:54Z",
+            "dateModified": "2021-12-11T11:49:27Z"
+        }
+    },
+    {
+        "key": "WJZFXUQA",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WJZFXUQA",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WJZFXUQA",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bagnall",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bagnall, Roger. &#x201C;Shenoute&#x2019;s Name.&#x201D; <i>ISAW Papers</i>, vol. 19, 2020, http://hdl.handle.net/2333.1/05qfv49m.</div>\n</div>",
+        "citation": "<span>(Bagnall)</span>",
+        "data": {
+            "key": "WJZFXUQA",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Shenoute's Name",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Roger",
+                    "lastName": "Bagnall"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "19",
+            "issue": "",
+            "pages": "",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/05qfv49m",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-05T19:26:11Z",
+            "dateModified": "2021-12-11T11:49:27Z"
+        }
+    },
+    {
+        "key": "QT9TQB6W",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QT9TQB6W",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QT9TQB6W",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Renberg",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Renberg, Gil H. &#x201C;Incubation in Demotic Literature.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 8, 2020, http://hdl.handle.net/2333.1/4f4qrrdk.</div>\n</div>",
+        "citation": "<span>(Renberg)</span>",
+        "data": {
+            "key": "QT9TQB6W",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Incubation in Demotic Literature",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Gil H.",
+                    "lastName": "Renberg"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "8",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/4f4qrrdk",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:14:49Z",
+            "dateModified": "2021-12-11T11:49:26Z"
+        }
+    },
+    {
+        "key": "8JUQ7X6F",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8JUQ7X6F",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8JUQ7X6F",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "McCollum",
+            "parsedDate": "2012",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">McCollum, Adam. &#x201C;A Syriac Fragment from The Cause of All Causes on the Pillars of Hercules.&#x201D; <i>ISAW Papers</i>, vol. 5, 2012, http://dlib.nyu.edu/awdl/isaw/isaw-papers/5/.</div>\n</div>",
+        "citation": "<span>(McCollum)</span>",
+        "data": {
+            "key": "8JUQ7X6F",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "A Syriac Fragment from The Cause of All Causes on the Pillars of Hercules",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Adam",
+                    "lastName": "McCollum"
+                }
+            ],
+            "abstractNote": "This brief note draws attention to a passage from the Syriac Cause of All Causes that describes the Pillars of Hercules, but as being three in number rather than two. The Syriac text in question has been well-known since it was published in 1889. This particular passage is studied and commented on here especially as it appears in a recently cataloged manuscript from Dayr Al-Za‘farān, in which the passage is completely divorced from its context in the Cause of All Causes.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "5",
+            "issue": "",
+            "pages": "",
+            "date": "2012",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/5/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/464EPI4E"
+            },
+            "dateAdded": "2014-01-15T15:23:36Z",
+            "dateModified": "2021-12-11T11:49:26Z"
+        }
+    },
+    {
+        "key": "HMZ4FRKN",
+        "version": 559,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/HMZ4FRKN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/HMZ4FRKN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Elliott et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Elliott, Tom, et al., editors. &#x201C;Current Practice in Linked Open Data for the Ancient World.&#x201D; <i>ISAW Papers</i>, vol. 7, 2014, http://hdl.handle.net/2333.1/gxd256w7.</div>\n</div>",
+        "citation": "<span>(Elliott et al.)</span>",
+        "data": {
+            "key": "HMZ4FRKN",
+            "version": 559,
+            "itemType": "journalArticle",
+            "title": "Current Practice in Linked Open Data for the Ancient World",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "Reports on current work relevant to the role of Linked Open Data (LOD) in the study of the ancient world. As a term, LOD encompasses approaches to the publication of digital resources that emphasize stability, relatively fine-grained access to intellectual content via public URIs, and re-usability as defined both by publication of machine reabable data and by publication under licenses that permit further copying of available materials. This article presents a series of reports from participants in 2012 and 2013 sessions of the NEH-funded Linked Ancient World Data Institute. The contributors come from a wide range of academic disciplines and professional backgrounds. The projects they represent reflect this range and also illustrate many stages of the process of moving from concept to implementation.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "7",
+            "issue": "",
+            "pages": "",
+            "date": "2014",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/gxd256w7",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/NIZRC89W",
+                    "http://zotero.org/groups/242005/items/DLDDXZ5Z",
+                    "http://zotero.org/groups/242005/items/S5HYJC4E",
+                    "http://zotero.org/groups/242005/items/A8C5RSXP",
+                    "http://zotero.org/groups/242005/items/PIB52KQG",
+                    "http://zotero.org/groups/242005/items/54KMI6CT",
+                    "http://zotero.org/groups/242005/items/S5JAPYTD",
+                    "http://zotero.org/groups/242005/items/B3C4IUZ7",
+                    "http://zotero.org/groups/242005/items/L85BCVYT",
+                    "http://zotero.org/groups/242005/items/QVSNP45H",
+                    "http://zotero.org/groups/242005/items/XXG3TBBQ",
+                    "http://zotero.org/groups/242005/items/ESSXVZ6U",
+                    "http://zotero.org/groups/242005/items/JLAL7XRL"
+                ]
+            },
+            "dateAdded": "2014-01-16T19:06:31Z",
+            "dateModified": "2021-12-11T11:49:25Z"
+        }
+    },
+    {
+        "key": "AUKMM4A4",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/AUKMM4A4",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/AUKMM4A4",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Taylor",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Taylor, Michael J. &#x201C;Etruscan Identity and Service in the Roman Army: 300&#x2013;100 B.C.E.&#x201D; <i>American Journal of Archaeology</i>, vol. 121, no. 2, 2017, pp. 275&#x2013;92, https://doi.org/10/gnrdmd.</div>\n</div>",
+        "citation": "<span>(Taylor)</span>",
+        "data": {
+            "key": "AUKMM4A4",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Etruscan Identity and Service in the Roman Army: 300–100 B.C.E.",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Michael J.",
+                    "lastName": "Taylor"
+                }
+            ],
+            "abstractNote": "This article explores how Etruscan artwork presented soldiers in visual media during the Middle Roman Republic (ca. 300–100 B.C.E.), a period when Etruscan communities were required to contribute contingents to the Roman army. It proposes a class-based model for how Etruscans formulated their military identities. Elite representations, in particular cavalry combat on cinerary urns, displayed elaborately hellenized soldiers rather than Roman-style combatants. Meanwhile, nonelite representations, primarily featuring infantrymen on more economically accessible votive figurines, either displayed hybrid panoply or made no attempt to differentiate the portrayed soldier from a generic Roman citizen legionary. In the realm of martial identity, Etruscan elites in visual media appeared culturally aloof from Rome as well as socially removed from common soldiers in their own communities. The article concludes by placing the corpus of Etruscan evidence in the context of more scattered evidence from across the peninsula and suggesting that the tendency of elites to eschew the Roman panoply in visual media, and of nonelites to partially or wholly embrace it, was widespread in Italy prior to the Social War.",
+            "publicationTitle": "American Journal of Archaeology",
+            "volume": "121",
+            "issue": "2",
+            "pages": "275-292",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdmd",
+            "ISSN": "0002-9114",
+            "shortTitle": "Etruscan Identity and Service in the Roman Army",
+            "url": "https://www.jstor.org/stable/10.3764/aja.121.2.0275",
+            "accessDate": "2021-04-15T16:24:07Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Archaeological Institute of America",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/NUG3PBSI"
+            },
+            "dateAdded": "2021-04-15T16:24:07Z",
+            "dateModified": "2021-12-11T11:49:25Z"
+        }
+    },
+    {
+        "key": "FZ5A69WJ",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/FZ5A69WJ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/FZ5A69WJ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Warren",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Warren, Meredith J. C. &#x201C;Tasting the Little Scroll: A Sensory Analysis of Divine Interaction in Revelation 10.8&#x2013;10.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 11, 2020, http://hdl.handle.net/2333.1/r4xgxq10.</div>\n</div>",
+        "citation": "<span>(Warren)</span>",
+        "data": {
+            "key": "FZ5A69WJ",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "Tasting the Little Scroll: A Sensory Analysis of Divine Interaction in Revelation 10.8–10",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Meredith J.C.",
+                    "lastName": "Warren"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "11",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/r4xgxq10",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:11:04Z",
+            "dateModified": "2021-12-11T11:49:25Z"
+        }
+    },
+    {
+        "key": "P3WI95NM",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/P3WI95NM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/P3WI95NM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Leidwanger et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Leidwanger, Justin, et al. &#x201C;The Sixth-Century CE Shipwreck at Marzamemi.&#x201D; <i>American Journal of Archaeology</i>, vol. 125, no. 2, 2021, pp. 283&#x2013;317, https://doi.org/10/gnrdmc.</div>\n</div>",
+        "citation": "<span>(Leidwanger et al.)</span>",
+        "data": {
+            "key": "P3WI95NM",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "The Sixth-Century CE Shipwreck at Marzamemi",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Justin",
+                    "lastName": "Leidwanger"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Elizabeth S.",
+                    "lastName": "Greene"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Donnelly"
+                }
+            ],
+            "abstractNote": "Between 2013 and 2019, collaborative survey and excavation were carried out on the sixth-century CE shipwreck at Marzamemi, in southeast Sicily, originally explored by Gerhard Kapitän in the 1960s. The vessel sank while carrying a primary cargo of nearly 100 tons of extensively prefabricated architectural materials, at least some intended for a church. New finds raise questions about the prevailing narrative of the wreck as emblematic of a stagnating Late Antique economy, revived only briefly by Justinian. Large but uneven numbers of worked stone elements complicate assumptions regarding their employment as a single set, while additional decorative materials suggest networks of artistry and agency that transcend a single journey. A smaller secondary cargo of amphoras, along with galley wares and other finds, reveals the extended commercial webs of this merchant vessel and its sailors. Considered together, the assemblage highlights the interdependence and blurring of boundaries between high-end and more mundane exchange. This report offers a new reading of the well-known Late Antique wreck and a more nuanced evaluation of the goods, people, and processes that tied together the Mediterranean during a transformative period toward the end of the Roman empire era.",
+            "publicationTitle": "American Journal of Archaeology",
+            "volume": "125",
+            "issue": "2",
+            "pages": "283-317",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdmc",
+            "ISSN": "0002-9114",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/10.3764/aja.125.2.0283",
+            "accessDate": "2021-04-15T16:28:31Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Archaeological Institute of America",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-04-15T16:28:31Z",
+            "dateModified": "2021-12-11T11:49:23Z"
+        }
+    },
+    {
+        "key": "RSR6AP3D",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/RSR6AP3D",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/RSR6AP3D",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Elliott et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Elliott, Tom, et al. &#x201C;Prologue and Introduction.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 1, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/elliott-heath-muccigrosso/.</div>\n</div>",
+        "citation": "<span>(Elliott et al.)</span>",
+        "data": {
+            "key": "RSR6AP3D",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Prologue and Introduction",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "1",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/elliott-heath-muccigrosso/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/DNTFILSI"
+            },
+            "dateAdded": "2021-04-15T16:38:15Z",
+            "dateModified": "2021-12-11T11:49:23Z"
+        }
+    },
+    {
+        "key": "QTPLFGM6",
+        "version": 525,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QTPLFGM6",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QTPLFGM6",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rossi and Fiorillo",
+            "parsedDate": "2020-12-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rossi, Corinna, and Fausta Fiorillo. &#x201C;The Vaults of Umm Al-Dabadib: Geometric Study.&#x201D; <i>Nexus Network Journal</i>, vol. 22, no. 4, Dec. 2020, pp. 1063&#x2013;80, https://doi.org/10/gnrdmb.</div>\n</div>",
+        "citation": "<span>(Rossi and Fiorillo)</span>",
+        "data": {
+            "key": "QTPLFGM6",
+            "version": 525,
+            "itemType": "journalArticle",
+            "title": "The Vaults of Umm al-Dabadib: Geometric Study",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Corinna",
+                    "lastName": "Rossi"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Fausta",
+                    "lastName": "Fiorillo"
+                }
+            ],
+            "abstractNote": "This article focuses on the shape of the vaults that cover the rooms of the Fort of Umm al-Dabadib (Kharga Oasis, Egypt’s Western Desert), dating to the Late Roman Period. This building is the central element of the contemporary Fortified Settlement, consisting of a dense, three-dimensional mosaic of domestic units, all covered by similar vaults, and belonging to a chain of similar installations. Two elements make Umm al-Dabadib an interesting case-study: the excellent preservation of its architectural remains, and the possibility to rely on an accurate photogrammetric survey of the entire built-up area. Thanks to this combination, it was possible to analyse the geometric shape of the vaults in connection to the ancient building techniques. The study determined that the vaults of the Fort are elliptical; this conclusion will impact on the study of all the similar settlements built in the Kharga Oasis, and possibly to other contemporary buildings elsewhere in Egypt.",
+            "publicationTitle": "Nexus Network Journal",
+            "volume": "22",
+            "issue": "4",
+            "pages": "1063-1080",
+            "date": "2020-12-01",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "Nexus Netw J",
+            "language": "en",
+            "DOI": "10/gnrdmb",
+            "ISSN": "1522-4600",
+            "shortTitle": "The Vaults of Umm al-Dabadib",
+            "url": "https://doi.org/10.1007/s00004-020-00532-x",
+            "accessDate": "2021-04-15T16:33:59Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Springer Link",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/2G8RZMJ3"
+            },
+            "dateAdded": "2021-04-15T16:33:59Z",
+            "dateModified": "2021-12-11T11:49:22Z"
+        }
+    },
+    {
+        "key": "3NQWUJY8",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/3NQWUJY8",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/3NQWUJY8",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Benefiel and Sprenkle",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Benefiel, Rebecca, and Sara Sprenkle. &#x201C;The Herculaneum Graffiti Project.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 4, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/benefiel-sprenkle/.</div>\n</div>",
+        "citation": "<span>(Benefiel and Sprenkle)</span>",
+        "data": {
+            "key": "3NQWUJY8",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "The Herculaneum Graffiti Project",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rebecca",
+                    "lastName": "Benefiel"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Sara",
+                    "lastName": "Sprenkle"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "4",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/benefiel-sprenkle/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:59:14Z",
+            "dateModified": "2021-12-11T11:49:21Z"
+        }
+    },
+    {
+        "key": "N6SU9XX9",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/N6SU9XX9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/N6SU9XX9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Almas et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Almas, Bridget, et al. &#x201C;Linked Data in the Perseus Digital Library.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 3, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/almas-babeu-krohn/.</div>\n</div>",
+        "citation": "<span>(Almas et al.)</span>",
+        "data": {
+            "key": "N6SU9XX9",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Linked Data in the Perseus Digital Library",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Bridget",
+                    "lastName": "Almas"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Alison",
+                    "lastName": "Babeu"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Anna",
+                    "lastName": "Krohn"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "3",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/almas-babeu-krohn/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:56:25Z",
+            "dateModified": "2021-12-11T11:49:21Z"
+        }
+    },
+    {
+        "key": "BDGLCS9T",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/BDGLCS9T",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/BDGLCS9T",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Horne",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Horne, Ryan. &#x201C;Beyond Maps as Images at the Ancient World Mapping Center.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 9, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/horne/.</div>\n</div>",
+        "citation": "<span>(Horne)</span>",
+        "data": {
+            "key": "BDGLCS9T",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Beyond Maps as Images at the Ancient World Mapping Center",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "9",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/horne/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/DNTFILSI"
+            },
+            "dateAdded": "2021-04-15T18:01:16Z",
+            "dateModified": "2021-12-11T11:49:20Z"
+        }
+    },
+    {
+        "key": "KX28E6YU",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/KX28E6YU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/KX28E6YU",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Elliot and Jones",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Elliot, Tom, and Charles Jones. &#x201C;Moving the Ancient World Online Forward.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 6, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/blackwell-smith/.</div>\n</div>",
+        "citation": "<span>(Elliot and Jones)</span>",
+        "data": {
+            "key": "KX28E6YU",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Moving the Ancient World Online Forward",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Tom",
+                    "lastName": "Elliot"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Charles",
+                    "lastName": "Jones"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "6",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/blackwell-smith/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T17:05:32Z",
+            "dateModified": "2021-12-11T11:49:20Z"
+        }
+    },
+    {
+        "key": "62K4W7W4",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/62K4W7W4",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/62K4W7W4",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Lorber and Meadows",
+            "parsedDate": "2012",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lorber, Catharine, and Andrew Meadows. &#x201C;Review of Ptolemaic Numismatics, 1996 to 2007.&#x201D; <i>ISAW Papers</i>, vol. 2, 2012, https://hdl.handle.net/2333.1/9s4mw84w.</div>\n</div>",
+        "citation": "<span>(Lorber and Meadows)</span>",
+        "data": {
+            "key": "62K4W7W4",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Review of Ptolemaic Numismatics, 1996 to 2007",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Catharine",
+                    "lastName": "Lorber"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Meadows"
+                }
+            ],
+            "abstractNote": "The authors review scholarship on Ptolemaic numismatics published between 1996 and 2007. They present the major conclusions of articles discussing the distribution, role in the economy, iconography, weights standards and other aspects of this important Hellenistic coinage.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "2",
+            "issue": "",
+            "pages": "",
+            "date": "2012",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "https://hdl.handle.net/2333.1/9s4mw84w",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/MN6IYTJ3"
+            },
+            "dateAdded": "2014-01-15T15:16:02Z",
+            "dateModified": "2021-12-11T11:49:19Z"
+        }
+    },
+    {
+        "key": "MN6IYTJ3",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/MN6IYTJ3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/MN6IYTJ3",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rosamilia",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rosamilia, Emilio. &#x201C;The Introduction of Bronze Standard in Cyrenaica: Evidence from the &#x2018;Damiergoi&#x2019; Accounts.&#x201D; <i>Zeitschrift F&#xFC;r Papyrologie Und Epigraphik</i>, vol. 201, 2017, pp. 139&#x2013;54, https://www.jstor.org/stable/26603762.</div>\n</div>",
+        "citation": "<span>(Rosamilia)</span>",
+        "data": {
+            "key": "MN6IYTJ3",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "The Introduction of Bronze Standard in Cyrenaica: Evidence from the \"Damiergoi\" Accounts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Emilio",
+                    "lastName": "Rosamilia"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Zeitschrift für Papyrologie und Epigraphik",
+            "volume": "201",
+            "issue": "",
+            "pages": "139-154",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "0084-5388",
+            "shortTitle": "The Introduction of Bronze Standard in Cyrenaica",
+            "url": "https://www.jstor.org/stable/26603762",
+            "accessDate": "2021-04-15T18:26:35Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Dr. Rudolf Habelt GmbH",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/62K4W7W4"
+            },
+            "dateAdded": "2021-04-15T18:26:35Z",
+            "dateModified": "2021-12-11T11:49:19Z"
+        }
+    },
+    {
+        "key": "AKPPK2AJ",
+        "version": 607,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/AKPPK2AJ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/AKPPK2AJ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Heath",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Heath, Sebastian. &#x201C;ISAW Papers: Towards a Journal as Linked Open Data.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 8, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/heath/.</div>\n</div>",
+        "citation": "<span>(Heath)</span>",
+        "data": {
+            "key": "AKPPK2AJ",
+            "version": 607,
+            "itemType": "journalArticle",
+            "title": "ISAW Papers: Towards a Journal as Linked Open Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "8",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/heath/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/69Y3ERPQ"
+            },
+            "dateAdded": "2021-04-15T17:59:55Z",
+            "dateModified": "2021-12-11T11:49:18Z"
+        }
+    },
+    {
+        "key": "Y7V8LTDI",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/Y7V8LTDI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/Y7V8LTDI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Acheson",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Acheson, Phoebe. &#x201C;Linked Open Bibliographies in Ancient Studies.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 2, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/acheson/.</div>\n</div>",
+        "citation": "<span>(Acheson)</span>",
+        "data": {
+            "key": "Y7V8LTDI",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Linked Open Bibliographies in Ancient Studies",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Phoebe",
+                    "lastName": "Acheson"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "2",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/acheson/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T16:54:53Z",
+            "dateModified": "2021-12-11T11:49:18Z"
+        }
+    },
+    {
+        "key": "IMT3YVSM",
+        "version": 524,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IMT3YVSM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IMT3YVSM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hafford",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hafford, William B. &#x201C;Linked Open Data and the Ur of the Chaldees Project.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 7, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/hafford/.</div>\n</div>",
+        "citation": "<span>(Hafford)</span>",
+        "data": {
+            "key": "IMT3YVSM",
+            "version": 524,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data and the Ur of the Chaldees Project",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "William B.",
+                    "lastName": "Hafford"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "7",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/hafford/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/3JA5PZZP"
+            },
+            "dateAdded": "2021-04-15T17:16:19Z",
+            "dateModified": "2021-12-11T11:49:17Z"
+        }
+    },
+    {
+        "key": "2G8RZMJ3",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/2G8RZMJ3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/2G8RZMJ3",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rossi",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rossi, Corinna. &#x201C;Egyptian Cubits and Late Roman Architecture: The Design of the Forts of the Kharga Oasis (Egypt).&#x201D; <i>ISAW Papers</i>, vol. 16, 2019, http://hdl.handle.net/2333.1/5tb2rmg1.</div>\n</div>",
+        "citation": "<span>(Rossi)</span>",
+        "data": {
+            "key": "2G8RZMJ3",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Egyptian cubits and Late Roman architecture: the design of the forts of the Kharga Oasis (Egypt)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Corinna",
+                    "lastName": "Rossi"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "16",
+            "issue": "",
+            "pages": "",
+            "date": "2019",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/5tb2rmg1",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/QTPLFGM6"
+            },
+            "dateAdded": "2021-04-06T17:33:06Z",
+            "dateModified": "2021-12-11T11:49:15Z"
+        }
+    },
+    {
+        "key": "FBT5M2QA",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/FBT5M2QA",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/FBT5M2QA",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Kansa",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Kansa, Eric C. &#x201C;Open Context and Linked Data.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 10, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/kansa/.</div>\n</div>",
+        "citation": "<span>(Kansa)</span>",
+        "data": {
+            "key": "FBT5M2QA",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Open Context and Linked Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Eric C.",
+                    "lastName": "Kansa"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "10",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/kansa/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/DPDXJ9FM",
+                    "http://zotero.org/groups/242005/items/F6W8SIWR"
+                ]
+            },
+            "dateAdded": "2021-04-15T19:05:17Z",
+            "dateModified": "2021-12-11T11:49:14Z"
+        }
+    },
+    {
+        "key": "6H9FKNVV",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6H9FKNVV",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6H9FKNVV",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Liuzzo",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Liuzzo, Pietro Maria. &#x201C;The Europeana Network of Ancient Greek and Latin Epigraphy (EAGLE).&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 12, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/liuzzo/.</div>\n</div>",
+        "citation": "<span>(Liuzzo)</span>",
+        "data": {
+            "key": "6H9FKNVV",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "The Europeana Network of Ancient Greek and Latin Epigraphy (EAGLE)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Pietro Maria",
+                    "lastName": "Liuzzo"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "12",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/liuzzo/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:24:37Z",
+            "dateModified": "2021-12-11T11:49:13Z"
+        }
+    },
+    {
+        "key": "P8NNKFVQ",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/P8NNKFVQ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/P8NNKFVQ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Wrisley",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Wrisley, David Joseph. &#x201C;Locating Medieval French, or Why We Collect and Visualize the Geographic Information of Texts.&#x201D; <i>Speculum</i>, vol. 92, no. S1, 2017, pp. S145&#x2013;69, https://doi.org/10/gf2fxz.</div>\n</div>",
+        "citation": "<span>(Wrisley)</span>",
+        "data": {
+            "key": "P8NNKFVQ",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Locating Medieval French, or Why We Collect and Visualize the Geographic Information of Texts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "David Joseph",
+                    "lastName": "Wrisley"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Speculum",
+            "volume": "92",
+            "issue": "S1",
+            "pages": "S145-S169",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gf2fxz",
+            "ISSN": "0038-7134",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/26583708",
+            "accessDate": "2021-04-15T19:09:18Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: [The University of Chicago Press, Medieval Academy of America]",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/KTXET3DJ"
+            },
+            "dateAdded": "2021-04-15T19:09:18Z",
+            "dateModified": "2021-12-11T11:49:12Z"
+        }
+    },
+    {
+        "key": "KTXET3DJ",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/KTXET3DJ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/KTXET3DJ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Lana",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lana, Maurizio. &#x201C;Geolat: Geography for Latin Literature.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 11, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/lana/.</div>\n</div>",
+        "citation": "<span>(Lana)</span>",
+        "data": {
+            "key": "KTXET3DJ",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Geolat: Geography for Latin Literature",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Maurizio",
+                    "lastName": "Lana"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "11",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/lana/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/P8NNKFVQ"
+            },
+            "dateAdded": "2021-04-15T19:06:36Z",
+            "dateModified": "2021-12-11T11:49:12Z"
+        }
+    },
+    {
+        "key": "ZZX76PLW",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZZX76PLW",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZZX76PLW",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "MacKay",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">MacKay, Camilla. &#x201C;Bryn Mawr Classical Review.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 13, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/mackay/.</div>\n</div>",
+        "citation": "<span>(MacKay)</span>",
+        "data": {
+            "key": "ZZX76PLW",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Bryn Mawr Classical Review",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Camilla",
+                    "lastName": "MacKay"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "13",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/mackay/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:27:44Z",
+            "dateModified": "2021-12-11T11:49:11Z"
+        }
+    },
+    {
+        "key": "2LEFTXM3",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/2LEFTXM3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/2LEFTXM3",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "McMichael",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">McMichael, A. L. &#x201C;Byzantine Cappadocia: Small Data and the Dissertation.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 14, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/mcmichael/.</div>\n</div>",
+        "citation": "<span>(McMichael)</span>",
+        "data": {
+            "key": "2LEFTXM3",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Byzantine Cappadocia: Small Data and the Dissertation",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "A.L.",
+                    "lastName": "McMichael"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "14",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/mcmichael/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:28:31Z",
+            "dateModified": "2021-12-11T11:49:09Z"
+        }
+    },
+    {
+        "key": "XSBCCAU4",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/XSBCCAU4",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/XSBCCAU4",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Meadows and Gruber",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Meadows, Andrew, and Ethan Gruber. &#x201C;Coinage and Numismatic Methods. A Case Study of Linking a Discipline.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 15, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/meadows-gruber/.</div>\n</div>",
+        "citation": "<span>(Meadows and Gruber)</span>",
+        "data": {
+            "key": "XSBCCAU4",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Coinage and Numismatic Methods. A Case Study of Linking a Discipline",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Meadows"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ethan",
+                    "lastName": "Gruber"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "15",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/meadows-gruber/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/6QB9G8H9"
+            },
+            "dateAdded": "2021-04-15T19:29:44Z",
+            "dateModified": "2021-12-11T11:49:08Z"
+        }
+    },
+    {
+        "key": "4Y9XUGED",
+        "version": 523,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/4Y9XUGED",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/4Y9XUGED",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Meyers",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Meyers, Katy M. &#x201C;Exploring an Opportunity to Link the Dead in Ancient Rome.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 16, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/meyers/.</div>\n</div>",
+        "citation": "<span>(Meyers)</span>",
+        "data": {
+            "key": "4Y9XUGED",
+            "version": 523,
+            "itemType": "journalArticle",
+            "title": "Exploring an Opportunity to Link the Dead in Ancient Rome",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Katy M.",
+                    "lastName": "Meyers"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "16",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/meyers/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:31:31Z",
+            "dateModified": "2021-12-11T11:49:07Z"
+        }
+    },
+    {
+        "key": "BBLHRWFH",
+        "version": 519,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/BBLHRWFH",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/BBLHRWFH",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Longfellow and Swetnam-Burland",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Longfellow, Brenda, and Molly Swetnam-Burland. <i>Women&#x2019;s Lives, Women&#x2019;s Voices: Roman Material Culture and Female Agency in the Bay of Naples</i>. University of Texas Press, 2021.</div>\n</div>",
+        "citation": "<span>(Longfellow and Swetnam-Burland)</span>",
+        "data": {
+            "key": "BBLHRWFH",
+            "version": 519,
+            "itemType": "book",
+            "title": "Women's Lives, Women's Voices: Roman Material Culture and Female Agency in the Bay of Naples",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Brenda",
+                    "lastName": "Longfellow"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Molly",
+                    "lastName": "Swetnam-Burland"
+                }
+            ],
+            "abstractNote": "Literary evidence is often silent about the lives of women in antiquity, particularly those from the buried cities of Pompeii and Herculaneum. Even when women are considered, they are often seen through the lens of their male counterparts. In this collection, Brenda Longfellow and Molly Swetnam-Burland have gathered an outstanding group of scholars to give voice to both the elite and ordinary women living on the Bay of Naples before the eruption of Vesuvius. Using visual, architectural, archaeological, and epigraphic evidence, the authors consider how women in the region interacted with their communities through family relationships, businesses, and religious practices, in ways that could complement or complicate their primary social roles as mothers, daughters, and wives. They explore women-run businesses from weaving and innkeeping to prostitution, consider representations of women in portraits and graffiti, and examine how women expressed their identities in the funerary realm. Providing a new model for studying women in the ancient world, Women’s Lives, Women’s Voices brings to light the day-to-day activities of women of all classes in Pompeii and Herculaneum.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "University of Texas Press",
+            "date": "2021",
+            "numPages": "539",
+            "language": "en",
+            "ISBN": "978-1-4773-2360-1",
+            "shortTitle": "Women's Lives, Women's Voices",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-12-03T22:50:35Z",
+            "dateModified": "2021-12-03T22:51:02Z"
+        }
+    },
+    {
+        "key": "ESSXVZ6U",
+        "version": 510,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ESSXVZ6U",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ESSXVZ6U",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Cayless and Romanello",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Cayless, Hugh, and Matteo Romanello. &#x201C;Towards Resolution Services for Text URIs.&#x201D; <i>Graph Data-Models and Semantic Web Technologies in Scholarly Digital Editing</i>, edited by Elena Spadini et al., BoD &#x2013; Books on Demand, 2021, pp. 31-.</div>\n</div>",
+        "citation": "<span>(Cayless and Romanello)</span>",
+        "data": {
+            "key": "ESSXVZ6U",
+            "version": 510,
+            "itemType": "bookSection",
+            "title": "Towards resolution services for text URIs",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Hugh",
+                    "lastName": "Cayless"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Matteo",
+                    "lastName": "Romanello"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Elena",
+                    "lastName": "Spadini"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Francesca",
+                    "lastName": "Tomasi"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Georg",
+                    "lastName": "Vogeler"
+                }
+            ],
+            "abstractNote": "In scholarly digital editing, the established practice for semantically enriching digital texts is to add markup to a linear string of characters. Graph data-models provide an alternative approach, which is increasingly being given serious consideration. Labelled-property-graph databases, and the W3c's semantic web recommendation and associated standards (RDF and OWL) are powerful and flexible solutions to many of the problems that come with embedded markup. This volume explores the combination of scholarly digital editions, the graph data-model, and the semantic web from three perspectives: infrastructures and technologies, formal models, and projects and editions.",
+            "bookTitle": "Graph Data-Models and Semantic Web Technologies in Scholarly Digital Editing",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "BoD – Books on Demand",
+            "date": "2021",
+            "pages": "31-",
+            "language": "en",
+            "ISBN": "978-3-7543-4369-2",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-10-12T18:42:19Z",
+            "dateModified": "2021-10-12T18:46:03Z"
+        }
+    },
+    {
+        "key": "6QB9G8H9",
+        "version": 503,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6QB9G8H9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6QB9G8H9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Neumann",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Neumann, Kristina M. <i>Antioch in Syria: A History from Coins (300 BCE&#x2013;450 CE)</i>. Cambridge University Press, 2021.</div>\n</div>",
+        "citation": "<span>(Neumann)</span>",
+        "data": {
+            "key": "6QB9G8H9",
+            "version": 503,
+            "itemType": "book",
+            "title": "Antioch in Syria: A History from Coins (300 BCE–450 CE)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Kristina M.",
+                    "lastName": "Neumann"
+                }
+            ],
+            "abstractNote": "Antioch in Syria critically reassesses this ancient city from its Seleucid foundation into Late Antiquity. Although Antioch's prominence is famous, Kristina M. Neumann newly exposes the gradations of imperial power and local agency mediated within its walls through a comprehensive study of the coins minted there and excavated throughout the Mediterranean and Middle East. Patterns revealed through digital mapping and Exploratory Data Analysis serve as a significant index of spatial politics and the policies of the different authorities making use of the city. Evaluating the coins against other historical material reveals that Antioch's status was not fixed, nor the people passive pawns for external powers. Instead, as imperial governments capitalised upon Antioch's location and amenities, the citizens developed in their own distinct identities and agency. Antioch of the Antiochians must therefore be elevated from traditional narratives and static characterisations, being studied and celebrated for the dynamic polis it was.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Cambridge University Press",
+            "date": "2021",
+            "numPages": "439",
+            "language": "en",
+            "ISBN": "978-1-108-94487-8",
+            "shortTitle": "Antioch in Syria",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/XSBCCAU4"
+            },
+            "dateAdded": "2021-09-13T18:22:11Z",
+            "dateModified": "2021-09-13T18:22:29Z"
+        }
+    },
+    {
+        "key": "2BA25TAM",
+        "version": 487,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/2BA25TAM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/2BA25TAM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Marin",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Marin, Irene Soto. &#x201C;The Anabolikon Tax and the Study of the Linen Industry.&#x201D; <i>Ancient Taxation: The Mechanics of Extraction in Comparative Perspective</i>, edited by Jonathan Valk and Irene Soto Mar&#xED;n, NYU Press, 2021, pp. 343&#x2013;68.</div>\n</div>",
+        "citation": "<span>(Marin)</span>",
+        "data": {
+            "key": "2BA25TAM",
+            "version": 487,
+            "itemType": "bookSection",
+            "title": "The Anabolikon Tax and the Study of the Linen Industry",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Irene Soto",
+                    "lastName": "Marin"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Jonathan",
+                    "lastName": "Valk"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Irene Soto",
+                    "lastName": "Marín"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Ancient Taxation: The Mechanics of Extraction in Comparative Perspective",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "New York",
+            "publisher": "NYU Press",
+            "date": "2021",
+            "pages": "343-368",
+            "language": "en",
+            "ISBN": "978-1-4798-0619-5",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/QG6RGDC9"
+            },
+            "dateAdded": "2021-08-05T17:50:14Z",
+            "dateModified": "2021-08-05T17:51:55Z"
+        }
+    },
+    {
+        "key": "3JA5PZZP",
+        "version": 484,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/3JA5PZZP",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/3JA5PZZP",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hall et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hall, Margeret, et al. &#x201C;The Socialoid: A Computational Model of a City.&#x201D; <i>Market Engineering&#x202F;: Insights from Two Decades of Research on Markets and Information</i>, edited by Henner Gimpel et al., Springer International Publishing, 2021, pp. 199&#x2013;219, https://doi.org/10.1007/978-3-030-66661-3_12.</div>\n</div>",
+        "citation": "<span>(Hall et al.)</span>",
+        "data": {
+            "key": "3JA5PZZP",
+            "version": 484,
+            "itemType": "bookSection",
+            "title": "The Socialoid: A Computational Model of a City",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Margeret",
+                    "lastName": "Hall"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christian",
+                    "lastName": "Haas"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Johanna",
+                    "lastName": "Schacht"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Steven O.",
+                    "lastName": "Kimbrough"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Henner",
+                    "lastName": "Gimpel"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Jan",
+                    "lastName": "Krämer"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Dirk",
+                    "lastName": "Neumann"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Jella",
+                    "lastName": "Pfeiffer"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Stefan",
+                    "lastName": "Seifert"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Timm",
+                    "lastName": "Teubner"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Daniel J.",
+                    "lastName": "Veit"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Anke",
+                    "lastName": "Weidlich"
+                }
+            ],
+            "abstractNote": "A socialoid (our term) is an integrated collection of data and models about a society. As such, and accepting that it can never be complete, it is a computational model of a society. We are in the early stages of building a socialoid for Philadelphia, PA. We call it the Philadelphioid. The Philadelphioid is a diachronic (temporal), mashed, geographic information system (GIS) with an extensive integrated library of integrated analytics tools. The purpose of this chapter is to articulate our design rationale for the Philadelphioid and to illustrate its underlying concepts and premises. Central among these concepts is the principle of solution pluralism, which enjoins us to use analytics and visualization to create and explore multiple solutions to decision problems. We illustrate an application of this philosophy by discussing analysis pertaining to food deserts carried out with the Philadelphioid.",
+            "bookTitle": "Market Engineering : Insights from Two Decades of Research on Markets and Information",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Cham",
+            "publisher": "Springer International Publishing",
+            "date": "2021",
+            "pages": "199-219",
+            "language": "en",
+            "ISBN": "978-3-030-66661-3",
+            "shortTitle": "The Socialoid",
+            "url": "https://doi.org/10.1007/978-3-030-66661-3_12",
+            "accessDate": "2021-08-03T15:21:28Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Springer Link",
+            "callNumber": "",
+            "rights": "",
+            "extra": "DOI: 10.1007/978-3-030-66661-3_12",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/IMT3YVSM"
+            },
+            "dateAdded": "2021-08-03T15:21:28Z",
+            "dateModified": "2021-08-03T15:21:28Z"
+        }
+    },
+    {
+        "key": "M23ULELF",
+        "version": 482,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/M23ULELF",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/M23ULELF",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rochberg",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rochberg, Francesca. <i>Before Nature: Cuneiform Knowledge and the History of Science.</i> University of Chicago Press, 2020.</div>\n</div>",
+        "citation": "<span>(Rochberg)</span>",
+        "data": {
+            "key": "M23ULELF",
+            "version": 482,
+            "itemType": "book",
+            "title": "Before Nature: Cuneiform Knowledge and the History of Science.",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Francesca",
+                    "lastName": "Rochberg"
+                }
+            ],
+            "abstractNote": "",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Chicago",
+            "publisher": "University of Chicago Press",
+            "date": "2020",
+            "numPages": "",
+            "language": "English",
+            "ISBN": "978-0-226-75958-6",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "OCLC: 1152384924",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/INRT7FVK"
+            },
+            "dateAdded": "2021-08-03T14:37:41Z",
+            "dateModified": "2021-08-03T14:38:37Z"
+        }
+    },
+    {
+        "key": "6ZIG94CD",
+        "version": 473,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6ZIG94CD",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6ZIG94CD",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Dan-el",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Dan-el, Padilla Peralta. &#x201C;Gods of Trust: Ancient Delos and the Modern Economics of Religion.&#x201D; <i>Pilgrimage and Economy in the Ancient Mediterranean</i>, edited by Troels Myrup Kristensen and Anna Collar, Brill, 2020, pp. 329&#x2013;56.</div>\n</div>",
+        "citation": "<span>(Dan-el)</span>",
+        "data": {
+            "key": "6ZIG94CD",
+            "version": 473,
+            "itemType": "bookSection",
+            "title": "Gods of Trust: Ancient Delos and the Modern Economics of Religion",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Padilla Peralta",
+                    "lastName": "Dan-el"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Troels Myrup",
+                    "lastName": "Kristensen"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Anna",
+                    "lastName": "Collar"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Pilgrimage and Economy in the Ancient Mediterranean",
+            "series": "Religions in the Graeco-Roman World",
+            "seriesNumber": "192",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Leiden",
+            "publisher": "Brill",
+            "date": "2020",
+            "pages": "329-356",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HQSVSTD9"
+            },
+            "dateAdded": "2021-07-14T17:37:40Z",
+            "dateModified": "2021-07-14T17:40:48Z"
+        }
+    },
+    {
+        "key": "YCVAYAR6",
+        "version": 469,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/YCVAYAR6",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/YCVAYAR6",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Chaniotis",
+            "parsedDate": "2018",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Chaniotis, Angelos. <i>Age of Conquests: The Greek World from Alexander to Hadrian</i>. Harvard University Press, 2018.</div>\n</div>",
+        "citation": "<span>(Chaniotis)</span>",
+        "data": {
+            "key": "YCVAYAR6",
+            "version": 469,
+            "itemType": "book",
+            "title": "Age of Conquests: The Greek World from Alexander to Hadrian",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Angelos",
+                    "lastName": "Chaniotis"
+                }
+            ],
+            "abstractNote": "The world that Alexander remade in his lifetime was transformed once more by his death in 323 BCE. His successors reorganized Persian lands to create a new empire stretching from the eastern Mediterranean as far as present-day Afghanistan, while in Greece and Macedonia a fragile balance of power repeatedly dissolved into war. Then, from the late third century BCE to the end of the first, Rome's military and diplomatic might successively dismantled these post-Alexandrian political structures, one by one. During the Hellenistic period (c. 323-30 BCE), small polities struggled to retain the illusion of their identity and independence, in the face of violent antagonism among large states. With time, trade growth resumed and centers of intellectual and artistic achievement sprang up across a vast network, from Italy to Afghanistan and Russia to Ethiopia. But the death of Cleopatra in 30 BCE brought this Hellenistic moment to a close--or so the story goes. In Angelos Chaniotis's view, however, the Hellenistic world continued to Hadrian's death in 138 CE. Not only did Hellenistic social structures survive the coming of Rome, Chaniotis shows, but social, economic, and cultural trends that were set in motion between the deaths of Alexander and Cleopatra intensified during this extended period. Age of Conquests provides a compelling narrative of the main events that shaped ancient civilization during five crucial centuries. Many of these developments--globalization, the rise of megacities, technological progress, religious diversity, and rational governance--have parallels in our world today.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Harvard University Press",
+            "date": "2018",
+            "numPages": "481",
+            "language": "en",
+            "ISBN": "978-0-674-65964-3",
+            "shortTitle": "Age of Conquests",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-07-09T16:05:54Z",
+            "dateModified": "2021-07-09T16:06:22Z"
+        }
+    },
+    {
+        "key": "LIM5E67E",
+        "version": 460,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/LIM5E67E",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/LIM5E67E",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Tyson and Lang",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Tyson, Neil deGrasse, and Avis Lang. <i>Accessory to War: The Unspoken Alliance between Astrophysics and the Military</i>. 2019.</div>\n</div>",
+        "citation": "<span>(Tyson and Lang)</span>",
+        "data": {
+            "key": "LIM5E67E",
+            "version": 460,
+            "itemType": "book",
+            "title": "Accessory to war: the unspoken alliance between astrophysics and the military",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Neil deGrasse",
+                    "lastName": "Tyson"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Avis",
+                    "lastName": "Lang"
+                }
+            ],
+            "abstractNote": "\"In this far- reaching foray into the millennia- long relationship between science and military power, acclaimed astrophysicist and author of Astrophysics for People in a Hurry Neil deGrasse Tyson and Avis Lang examine how the methods and tools of astrophysics have been enlisted in the service of war. Spanning early celestial navigation to satellite- enabled warfare, Accessory to War is a richly researched and provocative examination of the intersection of science, technology, industry, and power that will introduce Tyson's millions of fans to yet another dimension of how the universe has shaped our lives and world.\" --From the publisher.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "",
+            "date": "2019",
+            "numPages": "",
+            "language": "English",
+            "ISBN": "978-0-393-35746-2",
+            "shortTitle": "Accessory to war",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Open WorldCat",
+            "callNumber": "",
+            "rights": "",
+            "extra": "OCLC: 1117715738",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-06-19T12:45:58Z",
+            "dateModified": "2021-06-19T12:45:58Z"
+        }
+    },
+    {
+        "key": "QVSNP45H",
+        "version": 444,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QVSNP45H",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QVSNP45H",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rabinowitz",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rabinowitz, Adam. &#x201C;Digital Surrogates: Archaeological Materialities.&#x201D; <i>Approaching Historical Sources in Their Contexts: Space, Time and Performance</i>, edited by Sarah Barber and Corinna M. Peniston-Bird, Taylor &amp; Francis Group, 2020, pp. 147&#x2013;65.</div>\n</div>",
+        "citation": "<span>(Rabinowitz)</span>",
+        "data": {
+            "key": "QVSNP45H",
+            "version": 444,
+            "itemType": "bookSection",
+            "title": "Digital surrogates: archaeological materialities",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Adam",
+                    "lastName": "Rabinowitz"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sarah",
+                    "lastName": "Barber"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Corinna M.",
+                    "lastName": "Peniston-Bird"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Approaching Historical Sources in Their Contexts: Space, Time and Performance",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Milton, UNITED KINGDOM",
+            "publisher": "Taylor & Francis Group",
+            "date": "2020",
+            "pages": "147-165",
+            "language": "",
+            "ISBN": "978-1-351-10656-6",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "History-Methodology.",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/HMZ4FRKN",
+                    "http://zotero.org/groups/242005/items/E5R4RYY5"
+                ]
+            },
+            "dateAdded": "2021-04-21T17:16:00Z",
+            "dateModified": "2021-04-21T17:19:03Z"
+        }
+    },
+    {
+        "key": "L85BCVYT",
+        "version": 439,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/L85BCVYT",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/L85BCVYT",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Barber and Peniston-Bird",
+            "parsedDate": "2020-04-13",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Barber, Sarah, and Corinna M. Peniston-Bird. <i>Approaching Historical Sources in Their Contexts: Space, Time and Performance</i>. Routledge, 2020.</div>\n</div>",
+        "citation": "<span>(Barber and Peniston-Bird)</span>",
+        "data": {
+            "key": "L85BCVYT",
+            "version": 439,
+            "itemType": "book",
+            "title": "Approaching Historical Sources in their Contexts: Space, Time and Performance",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sarah",
+                    "lastName": "Barber"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Corinna M.",
+                    "lastName": "Peniston-Bird"
+                }
+            ],
+            "abstractNote": "In Approaching Historical Sources in Their Contexts, 12 academics examine how space, time and performance interact to co-create context for source analysis. The chapters cover 2000 years and stretch across the Americas and Europe. They are grouped into three themes, with the first four exploring aspects of movement within and around an environment: buildings, the tension between habitat and tourist landscape, cemeteries and war memorials. Three chapters look at different aspects of performance: masque and opera in which performance is (re)constructed from several media, radio and television. The final group of chapters consider objects and material culture in which both spatial placement and performance influence how they might be read as historical sources: archaeological finds and their digital management, the display of objects in heritage locations, clothing, photograph albums and scrapbooks. Supported by a range of case studies, the contributors embed lessons and methodological approaches within their chapters that can be adapted and adopted by those working with similar sources, offering students both a theoretical and practical demonstration of how to analyse sources within their contexts. Drawing out common threads to help those wishing to illuminate their own historical investigation, this book encourages a broad and inclusive approach to the physical and social contexts of historical evidence for those undertaking source analysis.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Routledge",
+            "date": "2020-04-13",
+            "numPages": "255",
+            "language": "en",
+            "ISBN": "978-1-351-10655-9",
+            "shortTitle": "Approaching Historical Sources in their Contexts",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: iePcDwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "History / Historiography",
+                    "type": 1
+                },
+                {
+                    "tag": "History / World",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-18T23:04:30Z",
+            "dateModified": "2021-04-18T23:04:30Z"
+        }
+    },
+    {
+        "key": "HI88PIEU",
+        "version": 438,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/HI88PIEU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/HI88PIEU",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/L85BCVYT",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=iePcDwAAQBAJ. Accessed 18 Apr. 2021.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "HI88PIEU",
+            "version": 438,
+            "parentItem": "L85BCVYT",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2021-04-18T23:04:30Z",
+            "url": "https://www.google.com/books?id=iePcDwAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2021-04-18T23:04:30Z",
+            "dateModified": "2021-04-18T23:04:30Z"
+        }
+    },
+    {
+        "key": "464EPI4E",
+        "version": 437,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/464EPI4E",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/464EPI4E",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Boscs et al.",
+            "parsedDate": "2019-10-24",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Boscs, Fran&#xE7;oise des, et al. <i>Le d&#xE9;troit de Gibraltar (Antiquit&#xE9; - Moyen &#xC2;ge). I: Repr&#xE9;sentations, perceptions, imaginaires</i>. Casa de Vel&#xE1;zquez, 2019.</div>\n</div>",
+        "citation": "<span>(Boscs et al.)</span>",
+        "data": {
+            "key": "464EPI4E",
+            "version": 437,
+            "itemType": "book",
+            "title": "Le détroit de Gibraltar (Antiquité - Moyen Âge). I: Représentations, perceptions, imaginaires",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Françoise des",
+                    "lastName": "Boscs"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Yann",
+                    "lastName": "Dejugnat"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Arthur",
+                    "lastName": "Haushalter"
+                }
+            ],
+            "abstractNote": "Dépassant l&#39;approche limitée à une simple étude de l&#39;imaginaire mythique et merveilleux du détroit de Gibraltar, lieu des confins du « monde habité », ce livre explore de nouvelles sources et croise les regards qui se sont posés sur cet espace : regards des mythes, revisités par les textes médiévaux arabes et latins ; regards de savants, voyageurs et marins ; regards aussi des pouvoirs qui ont tour à tour contrôlé, ou tenté de le faire, ce seuil essentiel entre Méditerranée et Atlantique, entre Europe et Afrique, entre monde chrétien et monde musulman. Il est proposé ici une étude diachronique de l&#39;image que renvoie le détroit de Gibraltar depuis la présence romaine jusqu&#39;à la fin de la Reconquista.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Casa de Velázquez",
+            "date": "2019-10-24",
+            "numPages": "474",
+            "language": "fr",
+            "ISBN": "978-84-9096-161-2",
+            "shortTitle": "Le détroit de Gibraltar (Antiquité - Moyen Âge). I",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: YJK5DwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "History / Ancient / General",
+                    "type": 1
+                },
+                {
+                    "tag": "History / Europe / Medieval",
+                    "type": 1
+                },
+                {
+                    "tag": "History / General",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/8JUQ7X6F"
+            },
+            "dateAdded": "2021-04-18T22:58:45Z",
+            "dateModified": "2021-04-18T22:58:45Z"
+        }
+    },
+    {
+        "key": "HWDF8YP5",
+        "version": 435,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/HWDF8YP5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/HWDF8YP5",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Romanis",
+            "parsedDate": "2020-04",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Romanis, Federico De. <i>The Indo-Roman Pepper Trade and the Muziris Papyrus</i>. Oxford University Press, 2020.</div>\n</div>",
+        "citation": "<span>(Romanis)</span>",
+        "data": {
+            "key": "HWDF8YP5",
+            "version": 435,
+            "itemType": "book",
+            "title": "The Indo-Roman Pepper Trade and the Muziris Papyrus",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Federico De",
+                    "lastName": "Romanis"
+                }
+            ],
+            "abstractNote": "This volume presents a systematic and fresh interpretation of a mid-second-century AD papyrus - the so-called Muziris papyrus - which preserves on its two sides fragments of a unique pair of documents: on one side, a loan agreement to finance a commercial enterprise to South India and, on the other, an assessment of the fiscal value of a South Indian cargo imported on a ship named the Hermapollon. The two texts, whose informative potential has long been underexploited, clarify several aspects of the early Roman Empire's trade with South India, including transport logistics, financial and legal elements in the loan agreement funding the commercial enterprise, the trade goods included in the South Indian cargo, and the technicalities of calculating and collecting Roman customs duties on the Indian imports. This study also considers imperial fiscal policy as it related to the South Indian trade, the overall evolution of Rome's trade relations with South India, the structure and organization of South Indian trade stakeholders, and the role played by private tax-collectors. The in-depth analysis sheds new light on this important sector of the Roman economy during the first two centuries AD in two innovative ways: through a balanced consideration of South Indian sources and data, and by drawing comparisons with the pepper trade from late antiquity, the Middle Ages, and early modernity, resulting in a longue dur�e perspective on the western trade in South Indian pepper.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Oxford University Press",
+            "date": "2020-04",
+            "numPages": "408",
+            "language": "en",
+            "ISBN": "978-0-19-884234-7",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: jcjXDwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "History / Ancient / Greece",
+                    "type": 1
+                },
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/JC8QMZTU"
+            },
+            "dateAdded": "2021-04-18T22:55:22Z",
+            "dateModified": "2021-04-18T22:55:22Z"
+        }
+    },
+    {
+        "key": "9JIS4TS5",
+        "version": 423,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/9JIS4TS5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/9JIS4TS5",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/N5LRIHJ8",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=ETx7DQAAQBAJ. Accessed 18 Apr. 2021.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "9JIS4TS5",
+            "version": 423,
+            "parentItem": "N5LRIHJ8",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2021-04-18T22:09:51Z",
+            "url": "https://www.google.com/books?id=ETx7DQAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2021-04-18T22:09:59Z",
+            "dateModified": "2021-04-18T22:09:59Z"
+        }
+    },
+    {
+        "key": "S5JAPYTD",
+        "version": 411,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/S5JAPYTD",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/S5JAPYTD",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Geser",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Geser, Guntram. <i>Towards a Web of Archaeological Linked Open Data</i>. ARIADNE, 2016, http://legacy.ariadne-infrastructure.eu/wp-content/uploads/2019/01/ARIADNE_archaeological_LOD_study_10-2016-1.pdf.</div>\n</div>",
+        "citation": "<span>(Geser)</span>",
+        "data": {
+            "key": "S5JAPYTD",
+            "version": 411,
+            "itemType": "document",
+            "title": "Towards a Web of Archaeological Linked Open Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Guntram",
+                    "lastName": "Geser"
+                }
+            ],
+            "abstractNote": "",
+            "publisher": "ARIADNE",
+            "date": "2016",
+            "language": "",
+            "shortTitle": "",
+            "url": "http://legacy.ariadne-infrastructure.eu/wp-content/uploads/2019/01/ARIADNE_archaeological_LOD_study_10-2016-1.pdf",
+            "accessDate": "2021-04-17T15:52:46Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Cites many of the articles in ISAW Paper 7.",
+            "tags": [],
+            "collections": [],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T15:52:46Z",
+            "dateModified": "2021-04-17T15:54:16Z"
+        }
+    },
+    {
+        "key": "BBMNSAMH",
+        "version": 404,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/BBMNSAMH",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/BBMNSAMH",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Harris and Hunnel Chen",
+            "parsedDate": "2021-03-29",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Harris, William V., and Anne Hunnel Chen, editors. <i>Late-Antique Studies in Memory of Alan Cameron</i>. Brill, 2021, https://brill.com/view/title/59683.</div>\n</div>",
+        "citation": "<span>(Harris and Hunnel Chen)</span>",
+        "data": {
+            "key": "BBMNSAMH",
+            "version": 404,
+            "itemType": "book",
+            "title": "Late-Antique Studies in Memory of Alan Cameron",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "William V.",
+                    "lastName": "Harris"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Anne",
+                    "lastName": "Hunnel Chen"
+                }
+            ],
+            "abstractNote": "\"Late-Antique Studies in Memory of Alan Cameron\" published on 29 Mar 2021 by Brill.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Brill",
+            "date": "2021/03/29",
+            "numPages": "",
+            "language": "en",
+            "ISBN": "978-90-04-45279-4",
+            "shortTitle": "",
+            "url": "https://brill.com/view/title/59683",
+            "accessDate": "2021-04-15T22:31:47Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "brill.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publication Title: Late-Antique Studies in Memory of Alan Cameron",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T22:31:47Z",
+            "dateModified": "2021-04-17T13:14:56Z"
+        }
+    },
+    {
+        "key": "I92UGNRJ",
+        "version": 403,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/I92UGNRJ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/I92UGNRJ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Symons",
+            "parsedDate": "2019-12-02",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Symons, Sarah. <i>Down to the Hour: Short Time in the Ancient Mediterranean and Near East</i>. Brill, 2019.</div>\n</div>",
+        "citation": "<span>(Symons)</span>",
+        "data": {
+            "key": "I92UGNRJ",
+            "version": 403,
+            "itemType": "book",
+            "title": "Down to the Hour: Short Time in the Ancient Mediterranean and Near East",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sarah",
+                    "lastName": "Symons"
+                }
+            ],
+            "abstractNote": "This book offers perspectives on the interplay between short-term timekeeping technologies and their social contexts in ancient Egypt, Babylon, Greece, and Rome. It explores the origins of the \"hour\" as a temporal unit and illuminates timekeeping activities in antiquity.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Brill",
+            "date": "2019-12-02",
+            "numPages": "309",
+            "language": "en",
+            "ISBN": "978-90-04-41629-1",
+            "shortTitle": "Down to the Hour",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: GG3DDwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "Literary Criticism / Ancient & Classical",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/5A46BUSX",
+                    "http://zotero.org/groups/242005/items/INRT7FVK"
+                ]
+            },
+            "dateAdded": "2021-04-17T13:10:54Z",
+            "dateModified": "2021-04-17T13:13:31Z"
+        }
+    },
+    {
+        "key": "L4CUMRHE",
+        "version": 400,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/L4CUMRHE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/L4CUMRHE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Imhausen and Pommerening",
+            "parsedDate": "2016-11-21",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Imhausen, Annette, and Tanja Pommerening. <i>Translating Writings of Early Scholars in the Ancient Near East, Egypt, Greece and Rome: Methodological Aspects with Examples</i>. Walter de Gruyter GmbH &amp; Co KG, 2016.</div>\n</div>",
+        "citation": "<span>(Imhausen and Pommerening)</span>",
+        "data": {
+            "key": "L4CUMRHE",
+            "version": 400,
+            "itemType": "book",
+            "title": "Translating Writings of Early Scholars in the Ancient Near East, Egypt, Greece and Rome: Methodological Aspects with Examples",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Annette",
+                    "lastName": "Imhausen"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Tanja",
+                    "lastName": "Pommerening"
+                }
+            ],
+            "abstractNote": "Die Übersetzung antiker wissenschaftlicher Texte stellt Studierende wie Forschende immer wieder vor besondere Herausforderungen, auch deshalb, weil eine systematische Referenzgrundlage für den Umgang mit diesen Texten bislang fehlt. Im Rahmen eines von der Fritz Thyssen Stiftung geförderten Projektes haben einschlägige Wissenschaftshistoriker und -historikerinnen der Ägyptologie, Altorientalistik und Altphilologie grundsätzliche Probleme von Übersetzungen und mögliche Lösungen diskutiert. Das Ergebnis ist ein Methodenhandbuch, das Studierenden und Forschenden aus den entsprechenden Philologien, Natur-, Geschichts- und Kulturwissenschaften Grundlagen der Übersetzungspraxis und -methodik vermittelt. Mit ausgewählten Fallbeispielen aus den Bereichen der antiken Heilkunde, Astronomie, Astrologie und Mathematik, mit fachspezifischen Hinweisen auf Übersetzungs- und Kommentierungswege sowie mit fachbezogenen Übersichten über Hilfsmittel wird das Übersetzen und das Verständnis und die Bewertung bereits vorhandener Übersetzungen antiker wissenschaftlicher Texte erleichtert.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Walter de Gruyter GmbH & Co KG",
+            "date": "2016-11-21",
+            "numPages": "624",
+            "language": "de",
+            "ISBN": "978-3-11-044881-8",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: ETx7DQAAQBAJ",
+            "tags": [
+                {
+                    "tag": "History / Ancient / Egypt",
+                    "type": 1
+                },
+                {
+                    "tag": "History / Ancient / General",
+                    "type": 1
+                },
+                {
+                    "tag": "History / Middle East / General",
+                    "type": 1
+                },
+                {
+                    "tag": "Science / History",
+                    "type": 1
+                },
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/INRT7FVK"
+            },
+            "dateAdded": "2021-04-17T13:07:45Z",
+            "dateModified": "2021-04-17T13:08:16Z"
+        }
+    },
+    {
+        "key": "T732BN8R",
+        "version": 398,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/T732BN8R",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/T732BN8R",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/L4CUMRHE",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=ETx7DQAAQBAJ. Accessed 17 Apr. 2021.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "T732BN8R",
+            "version": 398,
+            "parentItem": "L4CUMRHE",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2021-04-17T13:07:45Z",
+            "url": "https://www.google.com/books?id=ETx7DQAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2021-04-17T13:07:45Z",
+            "dateModified": "2021-04-17T13:07:45Z"
+        }
+    },
+    {
+        "key": "UQDPNH94",
+        "version": 375,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/UQDPNH94",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/UQDPNH94",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Leidwanger",
+            "parsedDate": "2020",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Leidwanger, Justin. <i>Roman Seas: A Maritime Archaeology of Eastern Mediterranean Economies</i>. Oxford University Press, 2020, https://doi.org/10.1093/oso/9780190083656.001.0001.</div>\n</div>",
+        "citation": "<span>(Leidwanger)</span>",
+        "data": {
+            "key": "UQDPNH94",
+            "version": 375,
+            "itemType": "book",
+            "title": "Roman Seas: A Maritime Archaeology of Eastern Mediterranean Economies",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Justin",
+                    "lastName": "Leidwanger"
+                }
+            ],
+            "abstractNote": "",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Oxford",
+            "publisher": "Oxford University Press",
+            "date": "2020",
+            "numPages": "",
+            "language": "",
+            "ISBN": "978-0-19-008365-6",
+            "shortTitle": "Roman Seas",
+            "url": "https://doi.org/10.1093/oso/9780190083656.001.0001",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "DOI:10.1093/oso/9780190083656.001.0001",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-16T12:14:59Z",
+            "dateModified": "2021-04-16T12:18:02Z"
+        }
+    },
+    {
+        "key": "ZDM7D5M6",
+        "version": 369,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZDM7D5M6",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZDM7D5M6",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Naether",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Naether, Franziska. &#x201C;Wise Men and Women in Literary Papyri.&#x201D; <i>Proceedings of the 28th Congress of Papyrology: 2016 August 1-6; Barcelona</i>, edited by Alberto Nodar and Sof&#xED;a Torallas Tovar, Publicacions Abadia de Montserrat, 2019, pp. 105&#x2013;13, http://hdl.handle.net/10230/41902.</div>\n</div>",
+        "citation": "<span>(Naether)</span>",
+        "data": {
+            "key": "ZDM7D5M6",
+            "version": 369,
+            "itemType": "bookSection",
+            "title": "Wise Men and Women in Literary Papyri",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Alberto",
+                    "lastName": "Nodar"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sofía",
+                    "lastName": "Torallas Tovar"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Proceedings of the 28th Congress of Papyrology: 2016 August 1-6; Barcelona",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Barcelona",
+            "publisher": "Publicacions Abadia de Montserrat",
+            "date": "2019",
+            "pages": "105-113",
+            "language": "",
+            "ISBN": "978-84-9191-079-4",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/10230/41902",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/LJ62XZGH"
+            },
+            "dateAdded": "2021-04-16T12:01:52Z",
+            "dateModified": "2021-04-16T12:05:31Z"
+        }
+    },
+    {
+        "key": "DPDXJ9FM",
+        "version": 354,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/DPDXJ9FM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/DPDXJ9FM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Garstki",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Garstki, Kevin. <i>Digital Innovations in European Archaeology</i>. Cambridge University Press, 2020, https://www.cambridge.org/core/elements/digital-innovations-in-european-archaeology/BDEA933427350E7D500F773A31EC9F4B.</div>\n</div>",
+        "citation": "<span>(Garstki)</span>",
+        "data": {
+            "key": "DPDXJ9FM",
+            "version": 354,
+            "itemType": "book",
+            "title": "Digital Innovations in European Archaeology",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Kevin",
+                    "lastName": "Garstki"
+                }
+            ],
+            "abstractNote": "",
+            "series": "Elements in the Archaeology of Europe",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Cambridge University Press",
+            "date": "2020",
+            "numPages": "",
+            "language": "en",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "https://www.cambridge.org/core/elements/digital-innovations-in-european-archaeology/BDEA933427350E7D500F773A31EC9F4B",
+            "accessDate": "2021-04-15T22:13:25Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/FBT5M2QA"
+            },
+            "dateAdded": "2021-04-15T22:13:25Z",
+            "dateModified": "2021-04-15T22:16:25Z"
+        }
+    },
+    {
+        "key": "K7ISEYXV",
+        "version": 347,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/K7ISEYXV",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/K7ISEYXV",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Zerefos and Vardinoyannis",
+            "parsedDate": "2019-02-28",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Zerefos, Christos S., and Marianna V. Vardinoyannis. <i>Hellenistic Alexandria: Celebrating 24 Centuries &#x2013; Papers Presented at the Conference Held on December 13&#x2013;15 2017 at Acropolis Museum, Athens</i>. Archaeopress Publishing Ltd, 2019.</div>\n</div>",
+        "citation": "<span>(Zerefos and Vardinoyannis)</span>",
+        "data": {
+            "key": "K7ISEYXV",
+            "version": 347,
+            "itemType": "book",
+            "title": "Hellenistic Alexandria: Celebrating 24 Centuries – Papers presented at the conference held on December 13–15 2017 at Acropolis Museum, Athens",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christos S.",
+                    "lastName": "Zerefos"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Marianna V.",
+                    "lastName": "Vardinoyannis"
+                }
+            ],
+            "abstractNote": "Hellenistic Alexandria: Celebrating 24 Centuries' presents the proceedings of a conference held at the Acropolis Museum in Athens, on December 13–15, 2017, and includes high-level dialogues and philosophical discussions between international experts on Hellenistic Alexandria. The goal was to celebrate the 24 centuries which have elapsed since its foundation and the beginning of the Library and the Museum of Alexandria. The conference was divided into two parts, to include in the first part archaeology, history, philosophy, literature, art, culture and legal issues and in the second part science, medicine, technology and environment. A total of 28 original and peer-reviewed articles point to the importance of the brilliantly-original ideas that emerged during the Hellenistic age and the curious modernity of the whole atmosphere of the time. The range of presented topics covers a variety of new data on the foundation of Alexandria to comparison between Ptolemaic Alexandria and Ptolemaic Greece through philosophy, culture and drama to the forgotten revolution of science, medicine and the prevailing climatological and geophysical conditions throughout the Hellenistic Period. The conference and its proceedings were co-sponsored by the Μarianna V. Vardinoyannis Foundation, the Acropolis Museum, the Alexandria Center for Hellenistic Studies at Bibliotheca Alexandrina and the Mariolopoulos-Kanaginis Foundation for the Environmental Sciences. The Publication also celebrates the 10th anniversary of the Alexandria Center for Hellenistic Studies, a joint collaboration between the Bibliotheca Alexandrina, the Vardinoyannis Foundation and the University of Alexandria. Scholars from around the world follow the Center’s programme in various specialisations, ranging from historyliterature- art, to archaeology and architecture-philosophy, and science.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Archaeopress Publishing Ltd",
+            "date": "2019-02-28",
+            "numPages": "321",
+            "language": "en",
+            "ISBN": "978-1-78969-067-5",
+            "shortTitle": "Hellenistic Alexandria",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: IxUSEAAAQBAJ",
+            "tags": [
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T22:09:48Z",
+            "dateModified": "2021-04-15T22:09:48Z"
+        }
+    },
+    {
+        "key": "RXYBD7TU",
+        "version": 346,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/RXYBD7TU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/RXYBD7TU",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hunger and Steele",
+            "parsedDate": "2018-07-11",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hunger, Hermann, and John Steele. <i>The Babylonian Astronomical Compendium MUL.APIN</i>. Routledge, 2018.</div>\n</div>",
+        "citation": "<span>(Hunger and Steele)</span>",
+        "data": {
+            "key": "RXYBD7TU",
+            "version": 346,
+            "itemType": "book",
+            "title": "The Babylonian Astronomical Compendium MUL.APIN",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Hermann",
+                    "lastName": "Hunger"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Steele"
+                }
+            ],
+            "abstractNote": "MUL.APIN, written sometime before the 8th century BC, was the most widely copied astronomical text in ancient Mesopotamia: a compendium including information such as star lists, descriptions of planetary phases, mathematical schemes for the length of day and night, a discussion of the luni-solar calendar and rules for intercalation, and a short collection of celestial omens. This book contains an introductory essay, followed by a new edition of the text and a facing-page transliteration and English translation. Finally, the book contains a new and detailed commentary on the text. This is a fascinating study, and an important resource for anyone interested in the history of astronomy.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Routledge",
+            "date": "2018-07-11",
+            "numPages": "342",
+            "language": "en",
+            "ISBN": "978-1-351-68681-5",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: z7JjDwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "History / Ancient / General",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T22:09:08Z",
+            "dateModified": "2021-04-15T22:09:08Z"
+        }
+    },
+    {
+        "key": "F6W8SIWR",
+        "version": 342,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/F6W8SIWR",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/F6W8SIWR",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Caraher",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Caraher, William. &#x201C;Dissecting Digital Divides in Teaching.&#x201D; <i>DATAM: Digital Approaches to Teaching the Ancient Mediterranean</i>, edited by Sebastian Heath, The Digital Press at the University of North Dakota, 2020, pp. 71&#x2013;82.</div>\n</div>",
+        "citation": "<span>(Caraher)</span>",
+        "data": {
+            "key": "F6W8SIWR",
+            "version": 342,
+            "itemType": "bookSection",
+            "title": "Dissecting Digital Divides in Teaching",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "William",
+                    "lastName": "Caraher"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "DATAM: Digital Approaches to Teaching the Ancient Mediterranean",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Grand Forks",
+            "publisher": "The Digital Press at the University of North Dakota",
+            "date": "2020",
+            "pages": "71-82",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/FBT5M2QA"
+            },
+            "dateAdded": "2021-04-15T21:46:54Z",
+            "dateModified": "2021-04-15T21:48:20Z"
+        }
+    },
+    {
+        "key": "B76RR9QN",
+        "version": 338,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/B76RR9QN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/B76RR9QN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Berman et al.",
+            "parsedDate": "2016-08-08",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Berman, Merrick Lex, et al. <i>Placing Names: Enriching and Integrating Gazetteers</i>. Indiana University Press, 2016.</div>\n</div>",
+        "citation": "<span>(Berman et al.)</span>",
+        "data": {
+            "key": "B76RR9QN",
+            "version": 338,
+            "itemType": "book",
+            "title": "Placing Names: Enriching and Integrating Gazetteers",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Merrick Lex",
+                    "lastName": "Berman"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ruth",
+                    "lastName": "Mostern"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Humphrey",
+                    "lastName": "Southall"
+                }
+            ],
+            "abstractNote": "Well before the innovation of maps, gazetteers served as the main geographic referencing system for hundreds of years. Consisting of a specialized index of place names, gazetteers traditionally linked descriptive elements with topographic features and coordinates. Placing Names is inspired by that tradition of discursive place-making and by contemporary approaches to digital data management that have revived the gazetteer and guided its development in recent decades. Adopted by researchers in the Digital Humanities and Spatial Sciences, gazetteers provide a way to model the kind of complex cultural, vernacular, and perspectival ideas of place that can be located in texts and expanded into an interconnected framework of naming history. This volume brings together leading and emergent scholars to examine the history of the gazetteer, its important role in geographic information science, and its use to further the reach and impact of spatial reasoning into the digital age.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Indiana University Press",
+            "date": "2016-08-08",
+            "numPages": "279",
+            "language": "en",
+            "ISBN": "978-0-253-02256-1",
+            "shortTitle": "Placing Names",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "Social Science / Human Geography",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:40:26Z",
+            "dateModified": "2021-04-15T21:40:26Z"
+        }
+    },
+    {
+        "key": "7QG65U96",
+        "version": 337,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/7QG65U96",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/7QG65U96",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Orlandi et al.",
+            "parsedDate": "2014-09-11",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Orlandi, Silvia, et al. <i>Information Technologies for Epigraphy and Cultural Heritage: Proceedings of the First EAGLE International Conference</i>. Sapienza Universit&#xE0; Editrice, 2014.</div>\n</div>",
+        "citation": "<span>(Orlandi et al.)</span>",
+        "data": {
+            "key": "7QG65U96",
+            "version": 337,
+            "itemType": "book",
+            "title": "Information Technologies for Epigraphy and Cultural Heritage: Proceedings of the First EAGLE International Conference",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Silvia",
+                    "lastName": "Orlandi"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Raffaella",
+                    "lastName": "Santucci"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Vittore",
+                    "lastName": "Casarosa"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Pietro",
+                    "lastName": "Liuzzo"
+                }
+            ],
+            "abstractNote": "This peer-reviewed volume contains selected papers from the First EAGLE International Conference on Information Technologies for Epigraphy and Cultural Heritage, held in Paris between September 29 and October 1, 2014. Here are assembled for the first time in a unique volume contributions regarding all aspects of Digital Epigraphy: Models, Vocabularies, Translations, User Engagements, Image Analysis, 3D methodologies, and ongoing projects at the cutting edge of digital humanities. The scope of this book is not limited to Greek and Latin epigraphy; it provides an overview of projects related to all epigraphic inquiry and its related communities. This approach intends to furnish the reader with the broadest possible perspective of the discipline, while at the same time giving due attention to the specifics of unique issues.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Sapienza Università Editrice",
+            "date": "2014-09-11",
+            "numPages": "538",
+            "language": "en",
+            "ISBN": "978-88-98533-42-8",
+            "shortTitle": "Information Technologies for Epigraphy and Cultural Heritage",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: rVtwDwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "Technology & Engineering / Power Resources / Alternative & Renewable",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:39:24Z",
+            "dateModified": "2021-04-15T21:39:24Z"
+        }
+    },
+    {
+        "key": "GXU3S2HU",
+        "version": 382,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/GXU3S2HU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/GXU3S2HU",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Gillings et al.",
+            "parsedDate": "2020-01-16",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Gillings, Mark, et al. <i>Archaeological Spatial Analysis: A Methodological Guide</i>. Routledge, 2020.</div>\n</div>",
+        "citation": "<span>(Gillings et al.)</span>",
+        "data": {
+            "key": "GXU3S2HU",
+            "version": 382,
+            "itemType": "book",
+            "title": "Archaeological Spatial Analysis: A Methodological Guide",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Mark",
+                    "lastName": "Gillings"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Piraye",
+                    "lastName": "Hacıgüzeller"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Gary",
+                    "lastName": "Lock"
+                }
+            ],
+            "abstractNote": "Effective spatial analysis is an essential element of archaeological research; this book is a unique guide to choosing the appropriate technique, applying it correctly and understanding its implications both theoretically and practically.  Focusing upon the key techniques used in archaeological spatial analysis, this book provides the authoritative, yet accessible, methodological guide to the subject which has thus far been missing from the corpus. Each chapter tackles a specific technique or application area and follows a clear and coherent structure. First is a richly referenced introduction to the particular technique, followed by a detailed description of the methodology, then an archaeological case study to illustrate the application of the technique, and conclusions that point to the implications and potential of the technique within archaeology.  The book is designed to function as the main textbook for archaeological spatial analysis courses at undergraduate and post-graduate level, while its user-friendly structure makes it also suitable for self-learning by archaeology students as well as researchers and professionals.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Routledge",
+            "date": "2020-01-16",
+            "numPages": "545",
+            "language": "en",
+            "ISBN": "978-1-351-24384-1",
+            "shortTitle": "Archaeological Spatial Analysis",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: lz33DwAAQBAJ",
+            "tags": [
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/T79TMG8G"
+            },
+            "dateAdded": "2021-04-15T21:38:00Z",
+            "dateModified": "2021-04-15T21:38:00Z"
+        }
+    },
+    {
+        "key": "73WBPEYJ",
+        "version": 335,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/73WBPEYJ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/73WBPEYJ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Jones",
+            "parsedDate": "2017-01-02",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Jones, Alexander. <i>A Portable Cosmos: Revealing the Antikythera Mechanism, Scientific Wonder of the Ancient World</i>. Oxford University Press, 2017.</div>\n</div>",
+        "citation": "<span>(Jones)</span>",
+        "data": {
+            "key": "73WBPEYJ",
+            "version": 335,
+            "itemType": "book",
+            "title": "A Portable Cosmos: Revealing the Antikythera Mechanism, Scientific Wonder of the Ancient World",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                }
+            ],
+            "abstractNote": "From the Dead Sea Scrolls to the Terracotta Army, ancient artifacts have long fascinated the modern world. However, the importance of some discoveries is not always immediately understood. This was the case in 1901 when sponge divers retrieved a lump of corroded bronze from a shipwreck at the bottom of the Mediterranean Sea near the Greek island of Antikythera. Little did the divers know they had found the oldest known analog computer in the world, an astonishing device that once simulated the motions of the stars and planets as they were understood by ancient Greek astronomers. Its remains now consist of 82 fragments, many of them containing gears and plates engraved with Greek words, that scientists and scholars have pieced back together through painstaking inspection and deduction, aided by radiographic tools and surface imaging. More than a century after its discovery, many of the secrets locked in this mysterious device can now be revealed. In addition to chronicling the unlikely discovery of the Antikythera Mechanism, author Alexander Jones takes readers through a discussion of how the device worked, how and for what purpose it was created, and why it was on a ship that wrecked off the Greek coast around 60 BC. What the Mechanism has uncovered about Greco-Roman astronomy and scientific technology, and their place in Greek society, is truly amazing. The mechanical know-how that it embodied was more advanced than anything the Greeks were previously thought capable of, but the most recent research has revealed that its displays were designed so that an educated layman could understand the behavior of astronomical phenomena, and how intertwined they were with one's natural and social environment. It was at once a masterpiece of machinery as well as one of the first portable teaching devices. Written by a world-renowned expert on the Mechanism, A Portable Cosmos will fascinate all readers interested in ancient history, archaeology, and the history of science.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Oxford University Press",
+            "date": "2017-01-02",
+            "numPages": "313",
+            "language": "en",
+            "ISBN": "978-0-19-061858-2",
+            "shortTitle": "A Portable Cosmos",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: SF3ODQAAQBAJ",
+            "tags": [
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:31:09Z",
+            "dateModified": "2021-04-15T21:31:09Z"
+        }
+    },
+    {
+        "key": "5PKSQNFT",
+        "version": 381,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5PKSQNFT",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5PKSQNFT",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Reynolds",
+            "parsedDate": "2019",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Reynolds, Paul. <i>Excavations on the Vrina Plain. Volume 3: The Roman and Late Antique Pottery from the Vrina Plain Excavations</i>. Oxbow Books, 2019.</div>\n</div>",
+        "citation": "<span>(Reynolds)</span>",
+        "data": {
+            "key": "5PKSQNFT",
+            "version": 381,
+            "itemType": "book",
+            "title": "Excavations on the Vrina Plain. Volume 3: The Roman and late Antique pottery from the Vrina Plain excavations",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Reynolds"
+                }
+            ],
+            "abstractNote": "Butrint 6 describes the excavations carried out on the Vrina Plain by the Butrint Foundation from 20022007. Lying just to the south of the ancient port city of Butrint, these excavations have revealed a 1,300 year long story of a changing community that began in the 1st century AD, one which not only played its part in shaping the city of Butrint but also in how the city interacted and at times reacted to the changing political, economic and cultural situations occurring across the Mediterranean World over this period. Volume III discusses the Roman and Late Antique pottery from the Vrina Plain excavations. This detailed study of the ceramics follows the archaeological sequence recovered from the excavations in chronological order and provides a comprehensive and in depth review of the pottery, context by context, offering an important insight into the supply, as well as typology, of local and imported pottery available to the inhabitants of the Vrina Plain during this period. This is followed by a discussion on how the pottery trends found on the Vrina Plain relate to that of other sites in Butrint, both within the town (Triconch Palace; the Forum) and outside (Vrina Plain training school villa excavations; the villa of Diaporit). The volume also presents an overview of some of the principal typological developments found across Butrint so as to allow the reader to place the Vrina finds in context, including a discussion of a number of key contexts from the Forum, as well as the findings from thin-section petrology of some of the ceramics.",
+            "series": "Butrint",
+            "seriesNumber": "6",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Oxbow Books",
+            "date": "2019",
+            "numPages": "",
+            "language": "en",
+            "ISBN": "978-1-78925-224-8",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "History / Ancient / General",
+                    "type": 1
+                },
+                {
+                    "tag": "History / Ancient / Rome",
+                    "type": 1
+                },
+                {
+                    "tag": "History / General",
+                    "type": 1
+                },
+                {
+                    "tag": "Social Science / Archaeology",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-04-15T21:27:13Z",
+            "dateModified": "2021-04-15T21:28:30Z"
+        }
+    },
+    {
+        "key": "KW7KGHQF",
+        "version": 380,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/KW7KGHQF",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/KW7KGHQF",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Brown and Bloomsbury (Firm)",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Brown, Amelia Robertson, and Bloomsbury (Firm). <i>Corinth in Late Antiquity: A Greek, Roman and Christian City</i>. 2019, https://brad.idm.oclc.org/login?url=https://doi.org/10.5040/9781350985865?locatt=label:secondary_bloomsburyCollections.</div>\n</div>",
+        "citation": "<span>(Brown and Bloomsbury (Firm))</span>",
+        "data": {
+            "key": "KW7KGHQF",
+            "version": 380,
+            "itemType": "book",
+            "title": "Corinth in late antiquity: a Greek, Roman and Christian city",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Amelia Robertson",
+                    "lastName": "Brown"
+                },
+                {
+                    "creatorType": "author",
+                    "name": "Bloomsbury (Firm)"
+                }
+            ],
+            "abstractNote": "\"Late antique Corinth was on the front line of the radical political, economic and religious transformations that swept across the Mediterranean world from the second to sixth centuries CE. A strategic merchant city, it became a hugely important metropolis in Roman Greece and, later, a key focal point for early Christianity. In late antiquity, Corinthians recognised new Christian authorities; adopted novel rites of civic celebration and decoration; and destroyed, rebuilt and added to the city's ancient landscape and monuments. Drawing on evidence from ancient literary sources, extensive archaeological excavations and historical records, Amelia Brown here surveys this period of urban transformation, from the old Agora and temples to new churches and fortifications. Influenced by the methodological advances of urban studies, Brown demonstrates the many ways Corinthians responded to internal and external pressures by building, demolishing and repurposing urban public space, thus transforming Corinthian society, civic identity and urban infrastructure. In a departure from isolated textual and archaeological studies, she connects this process to broader changes in metropolitan life, contributing to the present understanding of urban experience in the late antique Mediterranean\"--",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "",
+            "date": "2019",
+            "numPages": "",
+            "language": "English",
+            "ISBN": "978-1-350-98586-5",
+            "shortTitle": "Corinth in late antiquity",
+            "url": "https://brad.idm.oclc.org/login?url=https://doi.org/10.5040/9781350985865?locatt=label:secondary_bloomsburyCollections",
+            "accessDate": "2021-04-15T21:24:13Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Open WorldCat",
+            "callNumber": "",
+            "rights": "",
+            "extra": "OCLC: 1166380872",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-04-15T21:24:13Z",
+            "dateModified": "2021-04-15T21:24:13Z"
+        }
+    },
+    {
+        "key": "CGYALFRK",
+        "version": 330,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/CGYALFRK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/CGYALFRK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Riggsby",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Riggsby, Andrew. <i>Mosaics of Knowledge: Representing Information in the Roman World</i>. Oxford University Press, 2019.</div>\n</div>",
+        "citation": "<span>(Riggsby)</span>",
+        "data": {
+            "key": "CGYALFRK",
+            "version": 330,
+            "itemType": "book",
+            "title": "Mosaics of Knowledge: Representing Information in the Roman World",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Riggsby"
+                }
+            ],
+            "abstractNote": "",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Oxford",
+            "publisher": "Oxford University Press",
+            "date": "2019",
+            "numPages": "",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:16:54Z",
+            "dateModified": "2021-04-15T21:20:06Z"
+        }
+    },
+    {
+        "key": "P77YCCX5",
+        "version": 326,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/P77YCCX5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/P77YCCX5",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bang",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bang, Peter Fibiger. &#x201C;Beyond Capitalism &#x2014; Conceptualising Ancient Trade through Friction, World Historical Context and Bazaars.&#x201D; <i>Dynamics of Production in the Ancient Near East</i>, edited by Juan Carlos Moreno Garc&#xED;a, Oxbow Books, 2016, https://www.jstor.org/stable/j.ctt1ggjkp3.8.</div>\n</div>",
+        "citation": "<span>(Bang)</span>",
+        "data": {
+            "key": "P77YCCX5",
+            "version": 326,
+            "itemType": "bookSection",
+            "title": "Beyond capitalism — conceptualising ancient trade through friction, world historical context and bazaars",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Peter Fibiger",
+                    "lastName": "Bang"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Juan Carlos Moreno",
+                    "lastName": "García"
+                }
+            ],
+            "abstractNote": "Here is a fascinating report from the daily life of a 5th century merchant.¹ The letter was sent from Alexandria in Egypt to his master upstream in the city of Oxyrhynchus. Leaving aside the missive’s shaky Greek literacy, difficult to convey in translation, we are given a vivid sense of a concrete commercial universe and the practical conduct of ancient trade. The hazards of travel, the payment of baksheesh or gratuities to people along the route, delays, possible abuse by soldiers and magistrates, an unforeseeable standstill in business, the need to travel on in search of a market in an",
+            "bookTitle": "Dynamics of Production in the Ancient Near East",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Oxbow Books",
+            "date": "2016",
+            "pages": "",
+            "language": "",
+            "ISBN": "978-1-78570-283-9",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/j.ctt1ggjkp3.8",
+            "accessDate": "2021-04-15T21:11:40Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-15T21:11:40Z",
+            "dateModified": "2021-04-15T21:11:40Z"
+        }
+    },
+    {
+        "key": "RWE8PR95",
+        "version": 324,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/RWE8PR95",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/RWE8PR95",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Jördens",
+            "parsedDate": "2018",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">J&#xF6;rdens, Andrea. &#x201C;Soknopaiu Nesos Disneyland?&#x201D; <i>Le Fayoum. Arch&#xE9;ologie - Histoire - Religion</i>, edited by Marie-Pierre Chaufray et al., 1st ed., Harrassowitz Verlag, 2018, pp. 55&#x2013;74, https://doi.org/10.2307/j.ctvcm4f67.7.</div>\n</div>",
+        "citation": "<span>(Jördens)</span>",
+        "data": {
+            "key": "RWE8PR95",
+            "version": 324,
+            "itemType": "bookSection",
+            "title": "Soknopaiu Nesos Disneyland?",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrea",
+                    "lastName": "Jördens"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Marie-Pierre",
+                    "lastName": "Chaufray"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ivan",
+                    "lastName": "Guermeur"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sandra",
+                    "lastName": "Lippert"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Vincent",
+                    "lastName": "Rondot"
+                }
+            ],
+            "abstractNote": "Schon seit den Anfängen der Forschungen zum griechisch-römischen Ägypten zählt das am Rand des Faijum gelegene Soknopaiu Nesos zu den berühmtesten Fundstätten dieser Epoche. Dies ist nicht nur der Fülle an Originaldokumenten in griechischer und demotischer Sprache, sondern auch den beachtlichen archäologischen Hinterlassenschaften zu danken, die uns nicht zuletzt die seit 2003 unter der Leitung von Mario Capasso und Paola Davoli durchgeführten Grabungskampagnen der Università del Salento jedes Jahr aufs neue eindrucksvoll vor Augen führen.¹ Gleichwohl gibt es nach wie vor eine Reihe offener Fragen zu diesem vermeintlich bestens bekannten Ort, namentlich diejenige nach seinem rätselhaften, da überraschend plötzlichen Ende;",
+            "bookTitle": "Le Fayoum. Archéologie - Histoire - Religion",
+            "series": "Actes du sixième colloque international, Montpellier, 26-28 octobre 2016",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "1",
+            "place": "",
+            "publisher": "Harrassowitz Verlag",
+            "date": "2018",
+            "pages": "55-74",
+            "language": "",
+            "ISBN": "978-3-447-10977-2",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/j.ctvcm4f67.7",
+            "accessDate": "2021-04-15T21:10:07Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "DOI: 10.2307/j.ctvcm4f67.7",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/NUG3PBSI"
+            },
+            "dateAdded": "2021-04-15T21:10:07Z",
+            "dateModified": "2021-04-15T21:10:07Z"
+        }
+    },
+    {
+        "key": "ZA55MNNE",
+        "version": 322,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZA55MNNE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZA55MNNE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Almas and Beaulieu",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Almas, Bridget, and Marie-Claire Beaulieu. &#x201C;The Perseids Platform:: Scholarship for All!&#x201D; <i>Digital Classics Outside the Echo-Chamber</i>, edited by Gabriel Bodard and Matteo Romanello, Ubiquity Press, 2016, pp. 171&#x2013;86, https://www.jstor.org/stable/j.ctv3s8tgt.14.</div>\n</div>",
+        "citation": "<span>(Almas and Beaulieu)</span>",
+        "data": {
+            "key": "ZA55MNNE",
+            "version": 322,
+            "itemType": "bookSection",
+            "title": "The Perseids Platform:: Scholarship for all!",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Bridget",
+                    "lastName": "Almas"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Marie-Claire",
+                    "lastName": "Beaulieu"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Gabriel",
+                    "lastName": "Bodard"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Matteo",
+                    "lastName": "Romanello"
+                }
+            ],
+            "abstractNote": "Current practice in Digital Humanities focuses heavily on crowdsourcing as a model for producing knowledge, vetting contributions, and in general, dealing with large datasets.¹ In Classics, the rapid growth of digital repositories and the increasing number of largely unedited and untranslated documents available online for processing—thousands of Greek and Latin inscriptions, 900 medieval manuscripts from e-codices and 250 from the Walters Art Museum, to name only those few—practically force us to abandon traditional single-scholar approaches to adapt to the realities of the digital age.² The needs are simple, yet challenging: we must process more documents, but we must",
+            "bookTitle": "Digital Classics Outside the Echo-Chamber",
+            "series": "Teaching, Knowledge Exchange & Public Engagement",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Ubiquity Press",
+            "date": "2016",
+            "pages": "171-186",
+            "language": "",
+            "ISBN": "978-1-909188-48-8",
+            "shortTitle": "The Perseids Platform",
+            "url": "https://www.jstor.org/stable/j.ctv3s8tgt.14",
+            "accessDate": "2021-04-15T21:09:26Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:09:26Z",
+            "dateModified": "2021-04-15T21:09:26Z"
+        }
+    },
+    {
+        "key": "UEF9LT9P",
+        "version": 274,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/UEF9LT9P",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/UEF9LT9P",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hollander",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hollander, David B. &#x201C;The Roman Economy in the Early Empire:: An Overview.&#x201D; <i>Paul and Economics</i>, edited by Thomas R. Blanton and Raymond Pickett, 1517 Media, 2017, pp. 1&#x2013;22, https://doi.org/10.2307/j.ctt1kgqtgr.6.</div>\n</div>",
+        "citation": "<span>(Hollander)</span>",
+        "data": {
+            "key": "UEF9LT9P",
+            "version": 274,
+            "itemType": "bookSection",
+            "title": "The Roman Economy in the Early Empire:: An Overview",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "David B.",
+                    "lastName": "Hollander"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Thomas R.",
+                    "lastName": "Blanton"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Raymond",
+                    "lastName": "Pickett"
+                }
+            ],
+            "abstractNote": "The century between Octavian’s victory over Antony and Cleopatra at Actium in 31 BCE and the civil wars of 69 CE was a time of great prosperity for the Roman people, if not for some of their subjects. This “happy period” of (relative) peace facilitated a substantial expansion of long-distance trade and, thanks to the immense revenues at their disposal, permitted Augustus and his Julio-Claudian successors to devote considerable sums to the Empire’s infrastructure (and self-aggrandizement). If you were a Roman citizen, it was a great time to be alive.¹  The last twenty-five years have been a similarly prosperous time",
+            "bookTitle": "Paul and Economics",
+            "series": "A Handbook",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "1517 Media",
+            "date": "2017",
+            "pages": "1-22",
+            "language": "",
+            "ISBN": "978-1-5064-0603-9",
+            "shortTitle": "The Roman Economy in the Early Empire",
+            "url": "https://www.jstor.org/stable/j.ctt1kgqtgr.6",
+            "accessDate": "2021-04-15T18:30:49Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "DOI: 10.2307/j.ctt1kgqtgr.6",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-15T18:30:49Z",
+            "dateModified": "2021-04-15T18:30:49Z"
+        }
+    },
+    {
+        "key": "NIZRC89W",
+        "version": 265,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/NIZRC89W",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/NIZRC89W",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Frey",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Frey, John. &#x201C;The ARCS Project: A &#x2BB;Middle Range&#x2BC; Approach to Digitised Archaeological Record.&#x201D; <i>Old Excavation Data. What Can We Do? Proceedings of the Workshop Held at 10th ICAANE in Vienna, April 2016</i>, edited by Edeltraud Asp&#xF6;ck et al., Verlag der &#xD6;sterreichischen Akademie der Wissenschaften, 2020, pp. 25&#x2013;36, http://doi.org/10.1553/0x003bca0e.</div>\n</div>",
+        "citation": "<span>(Frey)</span>",
+        "data": {
+            "key": "NIZRC89W",
+            "version": 265,
+            "itemType": "bookSection",
+            "title": "The ARCS Project: A ʻMiddle Rangeʼ Approach to Digitised Archaeological Record",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Frey"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Edeltraud",
+                    "lastName": "Aspöck"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Seta",
+                    "lastName": "Štuhec"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Karin",
+                    "lastName": "Kopetzky"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Matthias",
+                    "lastName": "Kucera"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Old Excavation Data. What Can We Do? Proceedings of the Workshop held at 10th ICAANE in Vienna, April 2016",
+            "series": "OREA",
+            "seriesNumber": "16",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Vienna",
+            "publisher": "Verlag der Österreichischen Akademie der Wissenschaften",
+            "date": "2020",
+            "pages": "25-36",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "http://doi.org/10.1553/0x003bca0e",
+            "accessDate": "2021-04-15T17:39:58Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-15T17:39:58Z",
+            "dateModified": "2021-04-15T17:47:45Z"
+        }
+    },
+    {
+        "key": "MVN2ZG5I",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/MVN2ZG5I",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/MVN2ZG5I",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Love",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Love, Edward. &#x201C;The Literary vs The Literal: The Narration of Magical Practices, Texts, and Their Practitioners in Setne I and II Compared with the so-Called Demotic and Greek Magical Papyri.&#x201D; <i>Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016</i>, edited by Franziska Naether, vol. 18, no. 5, 2020, http://hdl.handle.net/2333.1/hmgqnw66.</div>\n</div>",
+        "citation": "<span>(Love)</span>",
+        "data": {
+            "key": "MVN2ZG5I",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "The Literary vs The Literal: The narration of magical practices, texts, and their practitioners in Setne I and II compared with the so-called Demotic and Greek Magical Papyri",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Edward",
+                    "lastName": "Love"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "volume": "18",
+            "issue": "5",
+            "pages": "",
+            "date": "2020",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/hmgqnw66",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/TY2V8W6F"
+            },
+            "dateAdded": "2021-04-15T16:04:01Z",
+            "dateModified": "2021-04-15T16:04:31Z"
+        }
+    },
+    {
+        "key": "IZ4V9FNB",
+        "version": 158,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IZ4V9FNB",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IZ4V9FNB",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Temin",
+            "parsedDate": "2013",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Temin, Peter. <i>The Roman Market Economy</i>. Princeton University Press, 2013.</div>\n</div>",
+        "citation": "<span>(Temin)</span>",
+        "data": {
+            "key": "IZ4V9FNB",
+            "version": 158,
+            "itemType": "book",
+            "title": "The Roman Market Economy",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Peter",
+                    "lastName": "Temin"
+                }
+            ],
+            "abstractNote": "",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Princeton",
+            "publisher": "Princeton University Press",
+            "date": "2013",
+            "numPages": "",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-13T02:20:22Z",
+            "dateModified": "2021-04-13T02:21:07Z"
+        }
+    },
+    {
+        "key": "Z5XNRIFE",
+        "version": 150,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/Z5XNRIFE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/Z5XNRIFE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Dari-Mattiacci and Kehoe",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Dari-Mattiacci, Giuseppe, and Dennis Kehoe, editors. <i>Roman Law and Economics Volume I: Institutions and Organizations</i>. Oxford University Press, 2020.</div>\n</div>",
+        "citation": "<span>(Dari-Mattiacci and Kehoe)</span>",
+        "data": {
+            "key": "Z5XNRIFE",
+            "version": 150,
+            "itemType": "book",
+            "title": "Roman Law and Economics Volume I: Institutions and Organizations",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Giuseppe",
+                    "lastName": "Dari-Mattiacci"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Dennis",
+                    "lastName": "Kehoe"
+                }
+            ],
+            "abstractNote": "",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Oxford",
+            "publisher": "Oxford University Press",
+            "date": "2020",
+            "numPages": "",
+            "language": "",
+            "ISBN": "9780198787204",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Cites ISAW Papers 8 on p. 193.",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-13T00:02:37Z",
+            "dateModified": "2021-04-13T00:10:12Z"
+        }
+    }
+]

--- a/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.url
+++ b/src/jazkarta/zoterolib/tests/data/366224e380f80fe7a276e86c33028356918eac2fbbeb20b8decb076f5b50e515.url
@@ -1,0 +1,1 @@
+https://api.zotero.org/groups/242005/items?include=bib%2Ccitation%2Cdata&limit=100&start=100&style=modern-language-association

--- a/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.headers.json
+++ b/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.headers.json
@@ -1,0 +1,15 @@
+{
+  "Zotero-Schema-Version": "15",
+  "Last-Modified-Version": "608",
+  "Keep-Alive": "timeout=5, max=100",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "Vary": "Accept-Encoding",
+  "Content-Length": "53045",
+  "Server": "Apache/2.4.53 ()",
+  "Connection": "Keep-Alive",
+  "Link": "<https://api.zotero.org/groups/242005/items?include=bib%2Ccitation%2Cdata&limit=100&start=100&style=modern-language-association>; rel=\"next\", <https://api.zotero.org/groups/242005/items?include=bib%2Ccitation%2Cdata&limit=100&start=100&style=modern-language-association>; rel=\"last\", <https://www.zotero.org/groups/242005/items>; rel=\"alternate\"",
+  "Date": "Wed, 15 Jun 2022 19:41:30 GMT",
+  "Total-Results": "180",
+  "Zotero-API-Version": "3",
+  "Content-Type": "application/json"
+}

--- a/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.txt
+++ b/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.txt
@@ -1,0 +1,10831 @@
+[
+    {
+        "key": "69Y3ERPQ",
+        "version": 608,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/69Y3ERPQ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/69Y3ERPQ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Caraher",
+            "parsedDate": "2022",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Caraher, William. &#x201C;Collaborative Digital Publishing in Archaeology: Data, Workflows, and Books in the Age of Logistics.&#x201D; <i>Critical Archaeology in the Digital Age: Proceedings of the 12th IEMA Visiting Scholar&#x2019;s Conference</i>, edited by Kevin Garstki, Cotsen Institute of Archaeology, 2022, pp. 153&#x2013;64.</div>\n</div>",
+        "citation": "<span>(Caraher)</span>",
+        "data": {
+            "key": "69Y3ERPQ",
+            "version": 608,
+            "itemType": "bookSection",
+            "title": "Collaborative Digital Publishing in Archaeology: Data, Workflows, and Books in the Age of Logistics",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Kevin",
+                    "lastName": "Garstki"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "William",
+                    "lastName": "Caraher"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Critical Archaeology in the Digital Age: Proceedings of the 12th IEMA Visiting Scholar's Conference",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Los Angeles",
+            "publisher": "Cotsen Institute of Archaeology",
+            "date": "2022",
+            "pages": "153-164",
+            "language": "en",
+            "ISBN": "978-1-950446-26-1",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/AKPPK2AJ",
+                    "http://zotero.org/groups/242005/items/8DAPBQM3"
+                ]
+            },
+            "dateAdded": "2022-05-19T13:54:51Z",
+            "dateModified": "2022-05-19T13:59:28Z"
+        }
+    },
+    {
+        "key": "JTL2H8IF",
+        "version": 606,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/JTL2H8IF",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/JTL2H8IF",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Garstki",
+            "parsedDate": "2022-02-01",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Garstki, Kevin. <i>Critical Archaeology in the Digital Age: Proceedings of the 12th IEMA Visiting Scholar&#x2019;s Conference</i>. ISD LLC, 2022.</div>\n</div>",
+        "citation": "<span>(Garstki)</span>",
+        "data": {
+            "key": "JTL2H8IF",
+            "version": 606,
+            "itemType": "book",
+            "title": "Critical Archaeology in the Digital Age: Proceedings of the 12th IEMA Visiting Scholar's Conference",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Kevin",
+                    "lastName": "Garstki"
+                }
+            ],
+            "abstractNote": "Every part of archaeological practice is intimately tied to digital technologies, but how deeply do we really understand the ways these technologies impact the theoretical trends in archaeology, how these trends affect the adoption of these technologies, or how the use of technology alters our interactions with the human past? This volume suggests a critical approach to archaeology in a digital world, a purposeful and systematic application of digital tools in archaeology. This is a call to pay attention to your digital tools, to be explicit about how you are using them, and to understand how they work and impact your own practice. The chapters in this volume demonstrate how this critical, reflexive approach to archaeology in the digital age can be accomplished, touching on topics that include 3D data, predictive and procedural modelling, digital publishing, digital archiving, public and community engagement, ethics, and global sustainability. The scale and scope of this research demonstrates how necessary it is for all archaeological practitioners to approach this digital age with a critical perspective and to be purposeful in our use of digital technologies.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "ISD LLC",
+            "date": "2022-02-01",
+            "numPages": "226",
+            "language": "en",
+            "ISBN": "978-1-950446-26-1",
+            "shortTitle": "Critical Archaeology in the Digital Age",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: eCpmEAAAQBAJ",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2022-05-19T13:54:18Z",
+            "dateModified": "2022-05-19T13:54:51Z"
+        }
+    },
+    {
+        "key": "ZTRMHCGY",
+        "version": 595,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZTRMHCGY",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZTRMHCGY",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/JTL2H8IF",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=eCpmEAAAQBAJ. Accessed 19 May 2022.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "ZTRMHCGY",
+            "version": 595,
+            "parentItem": "JTL2H8IF",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2022-05-19T13:54:18Z",
+            "url": "https://www.google.com/books?id=eCpmEAAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2022-05-19T13:54:18Z",
+            "dateModified": "2022-05-19T13:54:18Z"
+        }
+    },
+    {
+        "key": "8F34F8P7",
+        "version": 594,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8F34F8P7",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8F34F8P7",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Leontsini et al.",
+            "parsedDate": "2022",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Leontsini, Maria, et al. &#x201C;Harbours and Anchorages in Corinthia and Argolis (North-Eastern Peloponnese) from the Early to the Middle Byzantine Period.&#x201D; <i>Seasides of Byzantium: Harbours and Anchorages of a Mediterranean Empire</i>, edited by Johannes Preiser-Kapeller et al., Propylaeum, 2022, pp. 153&#x2013;66, https://doi.org/10.11588/propylaeum.910.c12054.</div>\n</div>",
+        "citation": "<span>(Leontsini et al.)</span>",
+        "data": {
+            "key": "8F34F8P7",
+            "version": 594,
+            "itemType": "bookSection",
+            "title": "Harbours and Anchorages in Corinthia and Argolis (North-Eastern Peloponnese) from the Early to the Middle Byzantine Period",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Maria",
+                    "lastName": "Leontsini"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Eleni",
+                    "lastName": "Manolessou"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Angeliki",
+                    "lastName": "Panopoulou"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Johannes",
+                    "lastName": "Preiser-Kapeller"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Taxiarchis",
+                    "lastName": "Kolias"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Falko",
+                    "lastName": "Daim"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Seasides of Byzantium: Harbours and Anchorages of a Mediterranean Empire",
+            "series": "Byzanz zwischen Orient und Okzident",
+            "seriesNumber": "21",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Heidelberg",
+            "publisher": "Propylaeum",
+            "date": "2022",
+            "pages": "153-166",
+            "language": "",
+            "ISBN": "",
+            "shortTitle": "",
+            "url": "https://doi.org/10.11588/propylaeum.910.c12054",
+            "accessDate": "2022-04-28T14:45:02Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "personal",
+            "callNumber": "Harbors-Byzantium-NE-Pelo.pdf",
+            "rights": "",
+            "extra": "DOI:10.11588/propylaeum.910.c12054",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2022-04-28T14:50:45Z",
+            "dateModified": "2022-04-28T14:50:45Z"
+        }
+    },
+    {
+        "key": "8UAXIJEL",
+        "version": 592,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8UAXIJEL",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8UAXIJEL",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Voulgaris et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Voulgaris, Aristeidis, et al. &#x201C;Renumbering of the Antikythera Mechanism Saros Cells, Resulting from the Saros Spiral Mechanical Apokatastasis.&#x201D; <i>Mediterranean Archaeology and Archaeometry</i>, vol. 21, no. 2, 2021, pp. 107&#x2013;28, https://doi.org/10.5281/zenodo.4681723.</div>\n</div>",
+        "citation": "<span>(Voulgaris et al.)</span>",
+        "data": {
+            "key": "8UAXIJEL",
+            "version": 592,
+            "itemType": "journalArticle",
+            "title": "Renumbering of the Antikythera Mechanism Saros Cells, Resulting from the Saros Spiral Mechanical Apokatastasis",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Aristeidis",
+                    "lastName": "Voulgaris"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christophoros",
+                    "lastName": "Mouratidis"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andreas",
+                    "lastName": "Vossinakis"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "George",
+                    "lastName": "Bokovos"
+                }
+            ],
+            "abstractNote": "After studying the design geometry of the Antikythera Mechanism Saros spiral, new critical geometrical/mechanical characteristics of the Back plate design were detected. The geometrical characteristics related to the symmetry of the Antikythera Mechanism design, are independent to the present irregular\ndeformation of the Mechanism parts and were used as calibration points for the Saros spiral cells positional measurements. The Saros cells numbering was recalculated using the calibration points position. A correction of minus one to the currently accepted numbering of the Saros cells was applied. Following the new numbering, a new proper position for the (displaced) Saros pointer axis-g, in graphic design environment was calculated. The measurements were tested on a bronze reconstruction of the Back plate, by the authors. This research leads to a new important result that the Saros does not start in a random or arbitrary date but only when a solar eclipse occurs within a month. Additional results were also calculated regarding the symmetry of the eclipse events/sequence. The new Saros cell numbering strongly affects the calculations for the initial starting date of the Saros spiral and the eclipse events scheme of the Antikythera Mechanism",
+            "publicationTitle": "Mediterranean Archaeology and Archaeometry",
+            "volume": "21",
+            "issue": "2",
+            "pages": "107-128",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10.5281/zenodo.4681723",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/F6BFDH87"
+            },
+            "dateAdded": "2022-03-24T22:35:32Z",
+            "dateModified": "2022-03-24T22:40:28Z"
+        }
+    },
+    {
+        "key": "QIGL2GSN",
+        "version": 573,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QIGL2GSN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QIGL2GSN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Kelly",
+            "parsedDate": "2021-10-22",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Kelly, Paul. &#x201C;Third-Century Inflation Reassessed.&#x201D; <i>Theoretical Roman Archaeology Journal</i>, vol. 4, no. 1, Oct. 2021, https://doi.org/10.16995/traj.4338.</div>\n</div>",
+        "citation": "<span>(Kelly)</span>",
+        "data": {
+            "key": "QIGL2GSN",
+            "version": 573,
+            "itemType": "journalArticle",
+            "title": "Third-Century Inflation Reassessed",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Kelly"
+                }
+            ],
+            "abstractNote": "The conventional view of inflation in the Roman world, based on evidence from Roman Egypt, is that prices were steady from the middle of the first century AD until around AD 274, other than a doubling of prices between AD 160 and 190. By a quantitative treatment of the data for all available prices, and indicators of prices, this paper shows that this picture is broadly correct for wheat, but that prices for other goods increased throughout the period from AD 160 to 270. This pattern suggests that there were two co-existing market sectors. One for wheat, where prices appear to have been impacted by state action, and another where other commodities were left to find their own market level within a relatively free market.",
+            "publicationTitle": "Theoretical Roman Archaeology Journal",
+            "volume": "4",
+            "issue": "1",
+            "pages": "",
+            "date": "2021-10-22",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "eng",
+            "DOI": "10.16995/traj.4338",
+            "ISSN": "2515-2289",
+            "shortTitle": "",
+            "url": "https://traj.openlibhums.org/article/id/4338/",
+            "accessDate": "2022-03-24T22:29:47Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "traj.openlibhums.org",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Number: 1\nPublisher: Open Library of Humanities",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2022-03-24T22:29:47Z",
+            "dateModified": "2022-03-24T22:29:47Z"
+        }
+    },
+    {
+        "key": "KZTPXDV5",
+        "version": 571,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/KZTPXDV5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/KZTPXDV5",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Gansten",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Gansten, Martin. <i>Annual Predictive Techniques of the Greek, Arabic and Indian Astrologers</i>. The Wessex Astrologer, 2021.</div>\n</div>",
+        "citation": "<span>(Gansten)</span>",
+        "data": {
+            "key": "KZTPXDV5",
+            "version": 571,
+            "itemType": "book",
+            "title": "Annual Predictive Techniques of the Greek, Arabic and Indian Astrologers",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Martin",
+                    "lastName": "Gansten"
+                }
+            ],
+            "abstractNote": "Predictions for each year of life go back to the earliest times of Hellenistic astrology. Elaborated by Persian and Arabic astrologers who emphasized the revolution of the nativity, known today as the solar return chart, annual predictive techniques then spread eastward into India and westward into Latin Europe during the Middle Ages. For the first time, this book draws together material on annual predictions from ancient and medieval authors writing in Greek, Arabic and Sanskrit, demonstrating their methods with a wealth of present-day example charts.While covering historical background and principles of interpretation, Annual Predictive Techniques is above all a manual of practical astrology, a guide to concrete prediction intended for intermediate students. Separate chapters are devoted to illustrating the use of primary directions and profections together with anniversary transits. The reader is then shown how to integrate these techniques step by step with the solar return chart. The final chapter discusses ways of subdividing a year and identifying times of major importance.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "The Wessex Astrologer",
+            "date": "2021",
+            "numPages": "189",
+            "language": "en",
+            "ISBN": "978-1-910531-50-1",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: _ktIEAAAQBAJ",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/INRT7FVK"
+            },
+            "dateAdded": "2022-03-16T17:52:17Z",
+            "dateModified": "2022-03-16T17:52:30Z"
+        }
+    },
+    {
+        "key": "ILWDETK5",
+        "version": 570,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ILWDETK5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ILWDETK5",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/KZTPXDV5",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=_ktIEAAAQBAJ. Accessed 16 Mar. 2022.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "ILWDETK5",
+            "version": 570,
+            "parentItem": "KZTPXDV5",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2022-03-16T17:52:17Z",
+            "url": "https://www.google.com/books?id=_ktIEAAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2022-03-16T17:52:17Z",
+            "dateModified": "2022-03-16T17:52:17Z"
+        }
+    },
+    {
+        "key": "MDNSDVPU",
+        "version": 569,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/MDNSDVPU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/MDNSDVPU",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Waerzeggers",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Waerzeggers, Caroline. &#x201C;Digital Prosopography of Babylonia: New Horizons.&#x201D; <i>Bridging the Gap: Disciplines, Times, and Spaces in Dialogue &#x2013; Volume 1: Sessions 1, 2, and 5 from the Conference Broadening Horizons 6 Held at the Freie Universit&#xE4;t Berlin, 24&#x2013;28 June 2019</i>, edited by Christian W. Hess and Federico Manuelli, Archaeopress Publishing Ltd, 2021, pp. 81&#x2013;96.</div>\n</div>",
+        "citation": "<span>(Waerzeggers)</span>",
+        "data": {
+            "key": "MDNSDVPU",
+            "version": 569,
+            "itemType": "bookSection",
+            "title": "Digital Prosopography of Babylonia: New Horizons",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Caroline",
+                    "lastName": "Waerzeggers"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Christian W.",
+                    "lastName": "Hess"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Federico",
+                    "lastName": "Manuelli"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Bridging the Gap: Disciplines, Times, and Spaces in Dialogue – Volume 1: Sessions 1, 2, and 5 from the Conference Broadening Horizons 6 Held at the Freie Universität Berlin, 24–28 June 2019",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Oxford",
+            "publisher": "Archaeopress Publishing Ltd",
+            "date": "2021",
+            "pages": "81-96",
+            "language": "en",
+            "ISBN": "978-1-80327-095-1",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/4IFKI948"
+            },
+            "dateAdded": "2022-03-07T16:25:25Z",
+            "dateModified": "2022-03-07T16:29:27Z"
+        }
+    },
+    {
+        "key": "7H4YEZY3",
+        "version": 565,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/7H4YEZY3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/7H4YEZY3",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/MDNSDVPU",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=PatcEAAAQBAJ. Accessed 7 Mar. 2022.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "7H4YEZY3",
+            "version": 565,
+            "parentItem": "MDNSDVPU",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2022-03-07T16:25:25Z",
+            "url": "https://www.google.com/books?id=PatcEAAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2022-03-07T16:25:25Z",
+            "dateModified": "2022-03-07T16:25:25Z"
+        }
+    },
+    {
+        "key": "WF7DGLBQ",
+        "version": 563,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WF7DGLBQ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WF7DGLBQ",
+                "type": "text/html"
+            },
+            "up": {
+                "href": "https://api.zotero.org/groups/242005/items/UVVME6M9",
+                "type": "application/json"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            }
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\"><i>Google Books Link</i>. https://www.google.com/books?id=R2VUEAAAQBAJ. Accessed 2 Mar. 2022.</div>\n</div>",
+        "citation": "<span>(<i>Google Books Link</i>)</span>",
+        "data": {
+            "key": "WF7DGLBQ",
+            "version": 563,
+            "parentItem": "UVVME6M9",
+            "itemType": "attachment",
+            "linkMode": "linked_url",
+            "title": "Google Books Link",
+            "accessDate": "2022-03-02T13:51:23Z",
+            "url": "https://www.google.com/books?id=R2VUEAAAQBAJ",
+            "note": "",
+            "contentType": "text/html",
+            "charset": "",
+            "tags": [],
+            "relations": {},
+            "dateAdded": "2022-03-02T13:51:23Z",
+            "dateModified": "2022-03-02T13:51:23Z"
+        }
+    },
+    {
+        "key": "MNUZFL3I",
+        "version": 562,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/MNUZFL3I",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/MNUZFL3I",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bodard and Yordanova",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bodard, Gabriel, and Polina Yordanova. &#x201C;Publication, Testing and Visualization with EFES: A Tool for All Stages of the EpiDoc XML Editing Process.&#x201D; <i>Studia UBB Digitalia</i>, vol. 65, no. 1, 2020, pp. 17&#x2013;35, https://doi.org/10/gnrdmk.</div>\n</div>",
+        "citation": "<span>(Bodard and Yordanova)</span>",
+        "data": {
+            "key": "MNUZFL3I",
+            "version": 562,
+            "itemType": "journalArticle",
+            "title": "Publication, Testing and Visualization with EFES: A tool for all stages of the EpiDoc XML editing process",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Gabriel",
+                    "lastName": "Bodard"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Polina",
+                    "lastName": "Yordanova"
+                }
+            ],
+            "abstractNote": "EpiDoc is a set of recommendations, schema and other tools for the encoding of ancient texts, especially inscriptions and papyri, in TEI XML, that is now used by upwards of a hundred projects around the world, and large numbers of scholars seek training in EpiDoc encoding every year. The EpiDoc Front-End Services tool (EFES) was designed to fill the important need for a publication solution for researchers and editors who have produced EpiDoc encoded texts but do not have access to digital humanities support or a well- funded IT service to produce a publication for them.\nThis paper will discuss the use of EFES not only for final publication, but as a tool in the editing and publication workflow, by editors of inscriptions, papyri and similar texts including those on coins and seals. The edition visualisations, indexes and search interface produced by EFES are able to serve as part of the validation, correction and research apparatus for the author of an epigraphic corpus, iteratively improving the editions long before final publication. As we will argue, this research process is a key component of epigraphic and papyrological editing practice, and studying these needs will help us to further enhance the effectiveness of EFES as a tool.\nTo this end we also plan to add three major functionalities to the EFES toolbox: (1) date visualisation and filter—building on the existing “date slider,” and inspired by partner projects such as Pelagios and Godot; (2) geographic visualization features, again building on Pelagios code, allowing the display of locations within a corpus or from a specific set of search results in a map; (3) export of information and metadata from the corpus as Linked Open Data, following the recommendations of projects such as the Linked Places format, SNAP, Chronontology and Epigraphy.info, to enable the semantic sharing of data within and beyond the field of classical and historical editions.\nFinally, we will discuss the kinds of collaboration that will be required to bring about desired enhancements to the EFES toolset, especially in this age of research-focussed, short-term funding. Embedding essential infrastructure work of this kind in research applications for specific research and publication projects will almost certainly need to be part of the solution.",
+            "publicationTitle": "Studia UBB Digitalia",
+            "volume": "65",
+            "issue": "1",
+            "pages": "17-35",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdmk",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://studia.ubbcluj.ro/download/pdf/1328.pdf",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-08-09T13:21:32Z",
+            "dateModified": "2022-01-18T18:25:54Z"
+        }
+    },
+    {
+        "key": "269W5TLK",
+        "version": 555,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/269W5TLK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/269W5TLK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Maxim",
+            "parsedDate": "2021",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Maxim, Korolkov. &#x201C;Between Command and Market: Credit, Labour, and Accounting in the Qin Empire (221-207 BCE).&#x201D; <i>Between Command and Market: Economic Thought and Practice in Early China</i>, edited by Elisa Levi Sabattini and Christian Schwermann, Brill, 2021, pp. 162&#x2013;243.</div>\n</div>",
+        "citation": "<span>(Maxim)</span>",
+        "data": {
+            "key": "269W5TLK",
+            "version": 555,
+            "itemType": "bookSection",
+            "title": "Between Command and Market: Credit, Labour, and Accounting in the Qin Empire (221-207 BCE)",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Elisa Levi",
+                    "lastName": "Sabattini"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Christian",
+                    "lastName": "Schwermann"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Korolkov",
+                    "lastName": "Maxim"
+                }
+            ],
+            "abstractNote": "",
+            "bookTitle": "Between Command and Market: Economic Thought and Practice in Early China",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "Leiden",
+            "publisher": "Brill",
+            "date": "2021",
+            "pages": "162-243",
+            "language": "en",
+            "ISBN": "978-90-04-46643-2",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-12-31T05:25:41Z",
+            "dateModified": "2021-12-31T05:29:41Z"
+        }
+    },
+    {
+        "key": "GD58GU7B",
+        "version": 549,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/GD58GU7B",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/GD58GU7B",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Doksanalt",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Doksanalt, Ertekin. &#x201C;Knidos &#x2018;Li&#x307;man Caddesi&#x307;&#x2019; Ge&#xE7; Anti&#x307;k D&#xF6;nem At&#xF6;lye / D&#xFC;kk&#xE2;n Ve Buluntulari.&#x201D; <i>Olba</i>, vol. 28, 2020, pp. 377&#x2013;420, https://app.trdizin.gov.tr/makale/TXprNE5UWTRPQT09/knidos-liman-caddesi-gec-antik-donem-atolye-dukkan-ve-buluntulari.</div>\n</div>",
+        "citation": "<span>(Doksanalt)</span>",
+        "data": {
+            "key": "GD58GU7B",
+            "version": 549,
+            "itemType": "journalArticle",
+            "title": "Knidos ‘Li̇man Caddesi̇’ Geç Anti̇k Dönem Atölye / Dükkân Ve Buluntulari",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ertekin",
+                    "lastName": "Doksanalt"
+                }
+            ],
+            "abstractNote": "Knidos, situated at the southwestern tip of Asia Minor is a city with double-view and a grid (hippodamic) plan, located on two harbors. A building complex has been discovered in the south of the city consisting of seven juxtaposed quadrilateral Rooms and 4 sub-places belonging to the first three of these rooms at a distance of 45 meters from the starting point of the street which is called “Harbor Street”. This complex, which was constructed as part of a major renovation in the second quarter of the fourth century BC, was used for a row of shops in line. The changes in the plan and architectural factors detected on the site indicate that the building called “Room 4,” which is the main focus of this study, had a different function during the Roman Imperial period. This structure, which had been used as a modest shop during the late Classical and Hellenistic periods, became a splendid heroon with Corinthian distyle in antis during the late Antonine period. The heroon consisted of two sections, a rectangular planned Room, and a platform where the tomb of the heroon’s owner was located as well as a rectangular niche. “Room 4” was later turned into a workshop and/or shop with some changes during Late Antiquity. Although the current data show that the heroon was turned into a workshop, archaeological excavations could not identified what kind of a workshop or shop it was. However, the duct system, amphorae placed in it, the high-temperature furnace in the corner of the structure, heavy iron dross, a depot and containers for storage, and spatheia amphorae containing yellow paint indicate manufacturing activities based on a heating and cooling system. The transformation of the structure from heroon to workshop/shop is traced by the archaeological data, particularly coins found there, which show that this change took place around the first quarter of the fifth century AD. The data regarding the use of the workshop/shop are verified as reliable, again thanks to the coins. Bronze coins found in amphora nests and on the ground provide information about the last use of the structure. Based on these and extensive ceramic findings, the workshop/shop was used during the sixth century AD and abandoned in the mid-seventh century. Ceramic findings are directly connected to the last use of the structure, dated to the seventh century AD, are divided into four groups: fine ware (26%), cooking ware (12%), plain ware (26%), and amphorae (36%). The densest group that was brought to light was amphorae with 36%. This ratio should be deemed normal considering the storage, production, and commercial functions of the structure. This study offers new suggestions for the compromised dating of some forms found in the structure (African Red-Slip Hayes Form 109). The idea that spatheia amphorae, directly related to the original use phase of the workshop/shop in Late Antiquity, could have also been used for the transport of paint (sulfur or perite) can be discussed. This study provides some evaluations made based on daily usage types or secondary uses of some amphorae (spatheion) in antiquity. In this study, new suggestions about usage and contents of spatheion amphorae were given in the light of chemical analyzes. According to chemical analysis, three amphoras contain sulfur or perite. Similarly, the study focuses on secondary-use stoppers/pessoi samples formed by using pieces of terracotta pots or amphorae.",
+            "publicationTitle": "Olba",
+            "volume": "28",
+            "issue": "",
+            "pages": "377-420",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "1301-7667",
+            "shortTitle": "",
+            "url": "https://app.trdizin.gov.tr/makale/TXprNE5UWTRPQT09/knidos-liman-caddesi-gec-antik-donem-atolye-dukkan-ve-buluntulari",
+            "accessDate": "2021-12-20T19:56:59Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "personal",
+            "callNumber": "KNIDOS_LIMAN_CADDESI_GEC_ANTIK_DONEM_ATO.pdf",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-12-20T19:56:59Z",
+            "dateModified": "2021-12-20T21:31:32Z"
+        }
+    },
+    {
+        "key": "R38RHVA2",
+        "version": 539,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/R38RHVA2",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/R38RHVA2",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Giannopoulou",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Giannopoulou, M. &#x201C;Theoretical Analysis of the Lunar Epicyclic Pin and Aperture System in the Antikythera Mechanism.&#x201D; <i>Archaeoastronomy and Ancient Technologies</i>, vol. 4, no. 1, 2016, pp. 1&#x2013;18, https://doi.org/10/gns682.</div>\n</div>",
+        "citation": "<span>(Giannopoulou)</span>",
+        "data": {
+            "key": "R38RHVA2",
+            "version": 539,
+            "itemType": "journalArticle",
+            "title": "Theoretical analysis of the lunar Epicyclic pin and aperture system in the Antikythera mechanism",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "M.",
+                    "lastName": "Giannopoulou"
+                }
+            ],
+            "abstractNote": "In this paper I develop a theoretical analysis of a two gear eccentric system in the Antikythera Mechanism, the oldest known analog computer. One gear carries a pin and as it rotates it transmits the motion to the other gear, which has an aperture. The angular velocity of the second gear depends from the shape of the aperture. Until now it was believed that the aperture was an orthogonal parallelogram. Prof. Xenophon Moussas expressed the idea that its shape could also be an ellipse or ellipse like. In this work the shapes Slot, Ellipse and Parabola are examined. The resulting motion of the gears is determined by a model in the framework of Lagrangian Mechanics. The theoretical results of the three shapes are compared with ephemeris data in order to specify which of them fits better with the data.",
+            "publicationTitle": "Archaeoastronomy and Ancient Technologies",
+            "volume": "4",
+            "issue": "1",
+            "pages": "1-18",
+            "date": "2016",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gns682",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://cyberleninka.ru/article/n/theoretical-analysis-of-the-lunar-epicyclic-pin-and-aperture-system-in-the-antikythera-mechanism/pdf",
+            "accessDate": "2021-12-18T16:36:43Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "DOI.org (Datacite)",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Archaeoastronomy and Ancient Technologies",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-12-18T16:36:43Z",
+            "dateModified": "2021-12-19T11:13:47Z"
+        }
+    },
+    {
+        "key": "TY2V8W6F",
+        "version": 522,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/TY2V8W6F",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/TY2V8W6F",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Love",
+            "parsedDate": "2021-12-06",
+            "numChildren": 1
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Love, Edward O. D. <i>Script Switching in Roman Egypt: Case Studies in Script Conventions, Domains, Shift, and Obsolescence from Hieroglyphic, Hieratic, Demotic, and Old Coptic Manuscripts</i>. Walter de Gruyter GmbH &amp; Co KG, 2021.</div>\n</div>",
+        "citation": "<span>(Love)</span>",
+        "data": {
+            "key": "TY2V8W6F",
+            "version": 522,
+            "itemType": "book",
+            "title": "Script Switching in Roman Egypt: Case Studies in Script Conventions, Domains, Shift, and Obsolescence from Hieroglyphic, Hieratic, Demotic, and Old Coptic Manuscripts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Edward O. D.",
+                    "lastName": "Love"
+                }
+            ],
+            "abstractNote": "Script Switching in Roman Egypt studies the hieroglyphic, hieratic, demotic, and Old Coptic manuscripts which evidence the conventions governing script use, the domains of writing those scripts inhabited, and the shift of scripts between those domains, to elucidate the obsolescence of those scripts from their domains during the Roman Period. Utilising macro-level frameworks from sociolinguistics, the textual culture from four sites is contextualised within the priestly communities of speech, script, and practice that produced them. Utilising micro-level frameworks from linguistics, both the scripts of the Egyptian writing system written, and the way the orthographic methods fundamental to those scripts changed, are typologised. This study also treats the way in which morphographic and alphabetic orthographies are deciphered and understood by the reading brain, and how changes in spelling over time both resulted from and responded to dimensions of orthographic depth. Through a cross-cultural consideration of script obsolescence in Mesoamerica and Mesopotamia and by analogy to language death in speech communities, a model of domain-bydomain shift and obsolescence of the scripts of the Egyptian writing system is proposed.",
+            "series": "",
+            "seriesNumber": "",
+            "volume": "",
+            "numberOfVolumes": "",
+            "edition": "",
+            "place": "",
+            "publisher": "Walter de Gruyter GmbH & Co KG",
+            "date": "2021-12-06",
+            "numPages": "416",
+            "language": "en",
+            "ISBN": "978-3-11-076843-5",
+            "shortTitle": "Script Switching in Roman Egypt",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Google Books",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Google-Books-ID: R2VUEAAAQBAJ",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/MVN2ZG5I"
+            },
+            "dateAdded": "2021-12-13T14:38:10Z",
+            "dateModified": "2021-12-13T14:38:10Z"
+        }
+    },
+    {
+        "key": "8P3TPZMC",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8P3TPZMC",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8P3TPZMC",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Romanello",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Romanello, Matteo. &#x201C;Mining Citations, Linking Texts.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 24, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/romanello/.</div>\n</div>",
+        "citation": "<span>(Romanello)</span>",
+        "data": {
+            "key": "8P3TPZMC",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Mining Citations, Linking Texts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Matteo",
+                    "lastName": "Romanello"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "24",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/romanello/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:52:18Z",
+            "dateModified": "2021-12-11T11:50:27Z"
+        }
+    },
+    {
+        "key": "T79TMG8G",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/T79TMG8G",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/T79TMG8G",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rabinowitz",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rabinowitz, Adam. &#x201C;It&#x2019;s about Time: Historical Periodization and Linked Ancient World Data.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 22, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/rabinowitz/.</div>\n</div>",
+        "citation": "<span>(Rabinowitz)</span>",
+        "data": {
+            "key": "T79TMG8G",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "It’s about time: historical periodization and Linked Ancient World Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Adam",
+                    "lastName": "Rabinowitz"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "22",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/rabinowitz/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/GXU3S2HU",
+                    "http://zotero.org/groups/242005/items/B3C4IUZ7",
+                    "http://zotero.org/groups/242005/items/6DAWH9QK",
+                    "http://zotero.org/groups/242005/items/IBE4TZCN"
+                ]
+            },
+            "dateAdded": "2021-04-15T19:48:25Z",
+            "dateModified": "2021-12-11T11:50:26Z"
+        }
+    },
+    {
+        "key": "RVL2PN5W",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/RVL2PN5W",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/RVL2PN5W",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Kotyk",
+            "parsedDate": "2018",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Kotyk, Jeffrey. &#x201C;Japanese Buddhist Astrology and Astral Magic: Mikky&#x14D; and Sukuy&#x14D;d&#x14D;.&#x201D; <i>Japanese Journal of Religious Studies</i>, vol. 45, no. 1, 2018, pp. 37&#x2013;86, https://doi.org/10/cqs2.</div>\n</div>",
+        "citation": "<span>(Kotyk)</span>",
+        "data": {
+            "key": "RVL2PN5W",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Japanese Buddhist Astrology and Astral Magic: Mikkyō and Sukuyōdō",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Jeffrey",
+                    "lastName": "Kotyk"
+                }
+            ],
+            "abstractNote": "This study investigates the sources of Japanese Buddhist astrology and astral magic while also examining their later developments, arguing that a significant amount of such arts actually originated in the Near East. Two types of Buddhist astrology are identified: “Mikkyō Astrology,” which was primarily used to determine auspicious days for rituals in Shingon and Tendai, and Sukuyōdō, the sole Japanese tradition to practice horoscopy. The role of astral magic within these Buddhist traditions is furthermore examined, with a particular focus on the Japanese reception of icons that in large part originated from Iranian sources that had been earlier received in Tang China. Finally, this study attempts to demonstrate the larger cultural significance of Buddhist astrology in medieval Japanese society.",
+            "publicationTitle": "Japanese Journal of Religious Studies",
+            "volume": "45",
+            "issue": "1",
+            "pages": "37-86",
+            "date": "2018",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/cqs2",
+            "ISSN": "0304-1042",
+            "shortTitle": "Japanese Buddhist Astrology and Astral Magic",
+            "url": "https://www.jstor.org/stable/26854471",
+            "accessDate": "2021-04-15T21:05:47Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Nanzan University",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5A46BUSX"
+            },
+            "dateAdded": "2021-04-15T21:05:47Z",
+            "dateModified": "2021-12-11T11:50:26Z"
+        }
+    },
+    {
+        "key": "9N5Q2W7F",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/9N5Q2W7F",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/9N5Q2W7F",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Blackwell and Smith",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Blackwell, Christopher, and D. Neel Smith. &#x201C;The Homer Multitext and RDF-Based Integration.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 5, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/blackwell-smith/.</div>\n</div>",
+        "citation": "<span>(Blackwell and Smith)</span>",
+        "data": {
+            "key": "9N5Q2W7F",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "The Homer Multitext and RDF-Based Integration",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christopher",
+                    "lastName": "Blackwell"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "D. Neel",
+                    "lastName": "Smith"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "5",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/blackwell-smith/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T20:19:35Z",
+            "dateModified": "2021-12-11T11:50:25Z"
+        }
+    },
+    {
+        "key": "KUYAWYLM",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/KUYAWYLM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/KUYAWYLM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Voulgaris et al.",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Voulgaris, Aristeidis, et al. &#x201C;Simulation and Analysis of Natural Seawater Chemical Reactions on the Antikythera Mechanism.&#x201D; <i>Journal of Coastal Research</i>, vol. 35, no. 5, 2019, pp. 959&#x2013;72, https://doi.org/10/gnrdmq.</div>\n</div>",
+        "citation": "<span>(Voulgaris et al.)</span>",
+        "data": {
+            "key": "KUYAWYLM",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Simulation and Analysis of Natural Seawater Chemical Reactions on the Antikythera Mechanism",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Aristeidis",
+                    "lastName": "Voulgaris"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christophoros",
+                    "lastName": "Mouratidis"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andreas",
+                    "lastName": "Vossinakis"
+                }
+            ],
+            "abstractNote": "Chemical reactions with seawater changed the bronze material and the color of the Antikythera Mechanism. The deformation and the displacement of the bronze parts are clearly evident on the visual photographs, on Antikythera Mechanism Research Project (AMRP) X-ray radiographs, and computed tomography (CT) scans as a result of the under-seawater material density change and the dehydration of the Mechanism after its removal from the Aegean/Kretan Sea bottom. In present work the first steps of the copper/bronze corrosion under the sea are simulated and presented. The geometric changes and the deformations of the Mechanism parts, which have repercussions on their shape, dimension, and relative position, are analyzed. Studying the visual photographs and the AMRP X-ray CTs of the partially preserved parts, the Functional Reconstruction of Antikythera Mechanism Project team digitally reconstructed and completed some of the lost/destroyed wooden and bronze parts and calculated the dimensions of the plates and the wooden casements of the Antikythera Mechanism ancient prototype.",
+            "publicationTitle": "Journal of Coastal Research",
+            "volume": "35",
+            "issue": "5",
+            "pages": "959-972",
+            "date": "2019",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdmq",
+            "ISSN": "0749-0208",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/26778545",
+            "accessDate": "2021-04-15T21:07:51Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: [Allen Press, Coastal Education & Research Foundation, Inc.]",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/IG5FSTMD",
+                    "http://zotero.org/groups/242005/items/VQDAMNGH"
+                ]
+            },
+            "dateAdded": "2021-04-15T21:07:51Z",
+            "dateModified": "2021-12-11T11:50:24Z"
+        }
+    },
+    {
+        "key": "3L8NP73U",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/3L8NP73U",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/3L8NP73U",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Iversen",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Iversen, Paul A. &#x201C;The Calendar on the Antikythera Mechanism and the Corinthian Family of Calendars.&#x201D; <i>Hesperia: The Journal of the American School of Classical Studies at Athens</i>, vol. 86, no. 1, 2017, pp. 129&#x2013;203, https://doi.org/10/gfgj29.</div>\n</div>",
+        "citation": "<span>(Iversen)</span>",
+        "data": {
+            "key": "3L8NP73U",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "The Calendar on the Antikythera Mechanism and the Corinthian Family of Calendars",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul A.",
+                    "lastName": "Iversen"
+                }
+            ],
+            "abstractNote": "This article explores the evidence for the Corinthian family of calendars in light of the calendar recently discovered on the Metonic Spiral of the Antikythera Mechanism. It will be argued that the calendar on the Antikythera Mechanism cannot be that of Syracuse, and that it is likely to be the Epirote calendar, possibly adopted from Corinthian Ambrakia. It will also be argued that the first month of this calendar, Phoinikaios, was ideally the month in which the autumn equinox fell, and that the start-up of the calendar began shortly after the astronomical new moon of August 23, 205 B.C. It will also be shown that the sixth set of games on the Games Dial are the Halieia of Rhodes, suggesting that the Antikythera Mechanism was built on Rhodes, possibly for a client from Epiros. Finally, there will be other observations on the Doric calendars of Argos, Epidauros, and Rhodes.",
+            "publicationTitle": "Hesperia: The Journal of the American School of Classical Studies at Athens",
+            "volume": "86",
+            "issue": "1",
+            "pages": "129-203",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gfgj29",
+            "ISSN": "0018-098X",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/10.2972/hesperia.86.1.0129",
+            "accessDate": "2021-04-15T21:02:05Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: The American School of Classical Studies at Athens",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:02:05Z",
+            "dateModified": "2021-12-11T11:50:23Z"
+        }
+    },
+    {
+        "key": "9USWD24D",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/9USWD24D",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/9USWD24D",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Simon et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Simon, Rainer, et al. &#x201C;Pelagios.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 27, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/simon-barker-desoto-isaksen/.</div>\n</div>",
+        "citation": "<span>(Simon et al.)</span>",
+        "data": {
+            "key": "9USWD24D",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Pelagios",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rainer",
+                    "lastName": "Simon"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Elton",
+                    "lastName": "Barker"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Pau",
+                    "lastName": "de Soto"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Leif",
+                    "lastName": "Isaksen"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "27",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/simon-barker-desoto-isaksen/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/B3C4IUZ7",
+                    "http://zotero.org/groups/242005/items/6DAWH9QK"
+                ]
+            },
+            "dateAdded": "2021-04-15T20:34:28Z",
+            "dateModified": "2021-12-11T11:50:22Z"
+        }
+    },
+    {
+        "key": "FPUMCBTA",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/FPUMCBTA",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/FPUMCBTA",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Poehler",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Poehler, Eric. &#x201C;Pompeii Bibliography and Mapping Resource.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 21, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/poehler/.</div>\n</div>",
+        "citation": "<span>(Poehler)</span>",
+        "data": {
+            "key": "FPUMCBTA",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "Pompeii Bibliography and Mapping Resource",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Eric",
+                    "lastName": "Poehler"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "21",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/poehler/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:44:10Z",
+            "dateModified": "2021-12-11T11:50:21Z"
+        }
+    },
+    {
+        "key": "E5R4RYY5",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/E5R4RYY5",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/E5R4RYY5",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Pett",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Pett, Daniel E. J. &#x201C;Linking Portable Antiquities to a Wider Web.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 20, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/pett/.</div>\n</div>",
+        "citation": "<span>(Pett)</span>",
+        "data": {
+            "key": "E5R4RYY5",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "Linking Portable Antiquities to a Wider Web",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Daniel E. J.",
+                    "lastName": "Pett"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "20",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/pett/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/QVSNP45H"
+            },
+            "dateAdded": "2021-04-15T19:41:44Z",
+            "dateModified": "2021-12-11T11:50:20Z"
+        }
+    },
+    {
+        "key": "IQP2Z3XT",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IQP2Z3XT",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IQP2Z3XT",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Taylor",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Taylor, Jon. &#x201C;Linked Data and the Future of Cuneiform Research at the British Museum.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 28, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/taylor/.</div>\n</div>",
+        "citation": "<span>(Taylor)</span>",
+        "data": {
+            "key": "IQP2Z3XT",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Linked data and the future of cuneiform research at the British Museum",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Jon",
+                    "lastName": "Taylor"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "28",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/taylor/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T20:40:01Z",
+            "dateModified": "2021-12-11T11:50:19Z"
+        }
+    },
+    {
+        "key": "7NNJCWG9",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/7NNJCWG9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/7NNJCWG9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Van Keer",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Van Keer, Elen. &#x201C;Moving from Cross-Collection Integration to Explorations of Linked Data Practices in the Library of Antiquity at the Royal Museums of Art and History, Brussels.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 30, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/vankeer/.</div>\n</div>",
+        "citation": "<span>(Van Keer)</span>",
+        "data": {
+            "key": "7NNJCWG9",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Moving from cross-collection integration to explorations of Linked Data practices in the library of antiquity at the Royal Museums of Art and history, Brussels",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Elen",
+                    "lastName": "Van Keer"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "30",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/vankeer/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/WQXYJU4U"
+            },
+            "dateAdded": "2021-04-15T20:43:22Z",
+            "dateModified": "2021-12-11T11:50:18Z"
+        }
+    },
+    {
+        "key": "4IFKI948",
+        "version": 569,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/4IFKI948",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/4IFKI948",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Pearce and Schmitz",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Pearce, Laurie, and Patrick Schmitz. &#x201C;Berkeley Prosopography Services.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 19, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/pearce-schmitz/.</div>\n</div>",
+        "citation": "<span>(Pearce and Schmitz)</span>",
+        "data": {
+            "key": "4IFKI948",
+            "version": 569,
+            "itemType": "journalArticle",
+            "title": "Berkeley Prosopography Services",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Laurie",
+                    "lastName": "Pearce"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Patrick",
+                    "lastName": "Schmitz"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "19",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/pearce-schmitz/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/MDNSDVPU"
+            },
+            "dateAdded": "2021-04-15T19:40:52Z",
+            "dateModified": "2021-12-11T11:50:17Z"
+        }
+    },
+    {
+        "key": "2HB53AIX",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/2HB53AIX",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/2HB53AIX",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Tsonev",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Tsonev, Tsoni. &#x201C;Integrating Historical-Geographic Web-Resources.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 29, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/tsonev/.</div>\n</div>",
+        "citation": "<span>(Tsonev)</span>",
+        "data": {
+            "key": "2HB53AIX",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Integrating Historical-Geographic Web-resources",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Tsoni",
+                    "lastName": "Tsonev"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "29",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/tsonev/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T20:41:22Z",
+            "dateModified": "2021-12-11T11:50:17Z"
+        }
+    },
+    {
+        "key": "A3DEQZAG",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/A3DEQZAG",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/A3DEQZAG",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Murray",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Murray, William. &#x201C;RAM3D Web Portal.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 17, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/murray/.</div>\n</div>",
+        "citation": "<span>(Murray)</span>",
+        "data": {
+            "key": "A3DEQZAG",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "RAM3D Web Portal",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "William",
+                    "lastName": "Murray"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "17",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/murray/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:32:53Z",
+            "dateModified": "2021-12-11T11:50:16Z"
+        }
+    },
+    {
+        "key": "E5G5KVQ9",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/E5G5KVQ9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/E5G5KVQ9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Reinhard",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Reinhard, Andrew. &#x201C;Publishing Archaeological Linked Open Data: From Steampunk to Sustainability.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 23, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/reinhard/.</div>\n</div>",
+        "citation": "<span>(Reinhard)</span>",
+        "data": {
+            "key": "E5G5KVQ9",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "Publishing Archaeological Linked Open Data: From Steampunk to Sustainability",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Reinhard"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "23",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/reinhard/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:50:34Z",
+            "dateModified": "2021-12-11T11:50:15Z"
+        }
+    },
+    {
+        "key": "NUG49QW2",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/NUG49QW2",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/NUG49QW2",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Nurmikko-Fuller",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Nurmikko-Fuller, Terhi. &#x201C;Assessing the Suitability of Existing OWL Ontologies for the Representation of Narrative Structures in Sumerian Literature.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 18, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/nurmikko-fuller/.</div>\n</div>",
+        "citation": "<span>(Nurmikko-Fuller)</span>",
+        "data": {
+            "key": "NUG49QW2",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "Assessing the Suitability of Existing OWL Ontologies for the Representation of Narrative Structures in Sumerian Literature",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Terhi",
+                    "lastName": "Nurmikko-Fuller"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "18",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/nurmikko-fuller/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T19:38:20Z",
+            "dateModified": "2021-12-11T11:50:15Z"
+        }
+    },
+    {
+        "key": "NUG3PBSI",
+        "version": 535,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/NUG3PBSI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/NUG3PBSI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Davoli and Miks",
+            "parsedDate": "2015",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Davoli, Paola, and Christian Miks. &#x201C;A New &#x2018;Roman&#x2019; Sword from Soknopaiou Nesos (El-Fayyum, Egypt).&#x201D; <i>ISAW Papers</i>, vol. 9, 2015, http://dlib.nyu.edu/awdl/isaw/isaw-papers/9/.</div>\n</div>",
+        "citation": "<span>(Davoli and Miks)</span>",
+        "data": {
+            "key": "NUG3PBSI",
+            "version": 535,
+            "itemType": "journalArticle",
+            "title": "A New “Roman” Sword from Soknopaiou Nesos (El-Fayyum, Egypt)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paola",
+                    "lastName": "Davoli"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christian",
+                    "lastName": "Miks"
+                }
+            ],
+            "abstractNote": "A long and well preserved sword was brought to light in 2006 during the archaeological excavations carried out by the Soknopaiou Nesos Project (University of Salento, Lecce) in the temenos of the main temple in Soknopaiou Nesos, modern Dime. The current state of research would suggest a classification as a Roman, or at least Roman influenced, weapon of the late Republican period. However, some peculiar elements of this sword seem to point to an oriental or Egyptian final assemblage. It thus may give a new impulse to the still open discussion about the appearance of Hellenistic swords starting from the period of Alexander's Successors. The weapon can have been used by soldiers of the late Ptolemaic period as well as by members of the Roman army. The question whether the sword ended up in the temenos as part of local defensive arms or as a votive object will largely remain speculative, as its find context is not stratigraphically reliable.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "9",
+            "issue": "",
+            "pages": "",
+            "date": "2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/9/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/AUKMM4A4",
+                    "http://zotero.org/groups/242005/items/RWE8PR95"
+                ]
+            },
+            "dateAdded": "2015-03-12T19:52:35Z",
+            "dateModified": "2021-12-11T11:50:15Z"
+        }
+    },
+    {
+        "key": "XJ47UDZN",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/XJ47UDZN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/XJ47UDZN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Seifried",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Seifried, Rebecca M. &#x201C;Linked Open Data for the Uninitiated.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 26, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/seifried/.</div>\n</div>",
+        "citation": "<span>(Seifried)</span>",
+        "data": {
+            "key": "XJ47UDZN",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for the Uninitiated",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rebecca M.",
+                    "lastName": "Seifried"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "26",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/seifried/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T20:32:07Z",
+            "dateModified": "2021-12-11T11:50:14Z"
+        }
+    },
+    {
+        "key": "SJL9ZARE",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/SJL9ZARE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/SJL9ZARE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Beaulieu et al.",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Beaulieu, Paul-Alain, et al. &#x201C;The Cuneiform Uranology Texts: Drawing the Constellations.&#x201D; <i>Transactions of the American Philosophical Society</i>, vol. 107, no. 2, 2017, pp. i&#x2013;121, https://www.jstor.org/stable/44810503.</div>\n</div>",
+        "citation": "<span>(Beaulieu et al.)</span>",
+        "data": {
+            "key": "SJL9ZARE",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "The Cuneiform Uranology Texts: Drawing the Constellations",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul-Alain",
+                    "lastName": "Beaulieu"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Eckart",
+                    "lastName": "Frahm"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Wayne",
+                    "lastName": "Horowitz"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Steele"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Transactions of the American Philosophical Society",
+            "volume": "107",
+            "issue": "2",
+            "pages": "i-121",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "0065-9746",
+            "shortTitle": "The Cuneiform Uranology Texts",
+            "url": "https://www.jstor.org/stable/44810503",
+            "accessDate": "2021-04-15T21:05:07Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: [American Philosophical Society, American Philosophical Association]",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:05:07Z",
+            "dateModified": "2021-12-11T11:50:14Z"
+        }
+    },
+    {
+        "key": "TSUFBR9W",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/TSUFBR9W",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/TSUFBR9W",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Steele",
+            "parsedDate": "2015",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Steele, J. M. &#x201C;A Late Babylonian Compendium of Calendrical and Stellar Astrology.&#x201D; <i>Journal of Cuneiform Studies</i>, vol. 67, 2015, pp. 187&#x2013;215, https://doi.org/10/gnrdm6.</div>\n</div>",
+        "citation": "<span>(Steele)</span>",
+        "data": {
+            "key": "TSUFBR9W",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "A Late Babylonian Compendium of Calendrical and Stellar Astrology",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "J. M.",
+                    "lastName": "Steele"
+                }
+            ],
+            "abstractNote": "Abstract BM 36303+36326, BM 36628+36786+36817+37178+37197, and BM 36988 are three fragments of what was once a large, almost square tablet containing a compendium of astrological texts. The compendium, which dates to sometime after the invention of the zodiac in the late fifth century BCE, contains sections that concern astrological geography, business and the height of the river Euphrates, astrological medicine, the Dodecatemoria and Kalendertext schemes, and the first occurrence in Babylonian sources of the so-called astrological doctrine of the Terms, which is well known from later Greek and Latin sources. Most of the material in the compendium is presented in the form of associations between astronomical and/or calendrical data and terrestrial counterparts rather than as omens. Some parts of the compendium duplicate material known from other texts, suggesting that the text was compiled by a scribe as a handy resource for his own use.",
+            "publicationTitle": "Journal of Cuneiform Studies",
+            "volume": "67",
+            "issue": "",
+            "pages": "187-215",
+            "date": "2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdm6",
+            "ISSN": "0022-0256",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/10.5615/jcunestud.67.2015.0187",
+            "accessDate": "2021-04-15T21:03:16Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: The American Schools of Oriental Research",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:03:16Z",
+            "dateModified": "2021-12-11T11:50:13Z"
+        }
+    },
+    {
+        "key": "P7GK4TFK",
+        "version": 534,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/P7GK4TFK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/P7GK4TFK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Roueché et al.",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rouech&#xE9;, Charlotte, et al. &#x201C;Linked Data and Ancient Wisdom.&#x201D; <i>Current Practice in Linked Open Data for the Ancient World</i>, edited by Tom Elliott et al., vol. 7, no. 25, 2014, http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/roueche-lawrence-lawrence/.</div>\n</div>",
+        "citation": "<span>(Roueché et al.)</span>",
+        "data": {
+            "key": "P7GK4TFK",
+            "version": 534,
+            "itemType": "journalArticle",
+            "title": "Linked Data and Ancient Wisdom",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Charlotte",
+                    "lastName": "Roueché"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Keith",
+                    "lastName": ""
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Lawrence",
+                    "lastName": "K. Faith"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Tom",
+                    "lastName": "Elliott"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "John",
+                    "lastName": "Muccigrosso"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Current Practice in Linked Open Data for the Ancient World",
+            "volume": "7",
+            "issue": "25",
+            "pages": "",
+            "date": "2014",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/7/roueche-lawrence-lawrence/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "SH96SDJZ"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T20:27:22Z",
+            "dateModified": "2021-12-11T11:50:13Z"
+        }
+    },
+    {
+        "key": "U6BB36MN",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/U6BB36MN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/U6BB36MN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Leidwanger",
+            "parsedDate": "2013",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Leidwanger, Justin. &#x201C;Between Local and Long-Distance: A Roman Shipwreck at Fig Tree Bay off SE Cyprus.&#x201D; <i>Journal of Roman Archaeology</i>, vol. 26, ed 2013, pp. 191&#x2013;208, https://doi.org/10/gnrdm5.</div>\n</div>",
+        "citation": "<span>(Leidwanger)</span>",
+        "data": {
+            "key": "U6BB36MN",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Between local and long-distance: a Roman shipwreck at Fig Tree Bay off SE Cyprus",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Justin",
+                    "lastName": "Leidwanger"
+                }
+            ],
+            "abstractNote": "//static.cambridge.org/content/id/urn%3Acambridge.org%3Aid%3Aarticle%3AS1047759413000123/resource/name/firstPage-S1047759413000123a.jpg",
+            "publicationTitle": "Journal of Roman Archaeology",
+            "volume": "26",
+            "issue": "",
+            "pages": "191-208",
+            "date": "2013/ed",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdm5",
+            "ISSN": "1047-7594, 2331-5709",
+            "shortTitle": "Between local and long-distance",
+            "url": "https://www.cambridge.org/core/journals/journal-of-roman-archaeology/article/abs/between-local-and-longdistance-a-roman-shipwreck-at-fig-tree-bay-off-se-cyprus/962B93B7855133F6C028B91BD7A19C90",
+            "accessDate": "2021-04-15T21:15:15Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Cambridge University Press",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Cambridge University Press",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T21:15:15Z",
+            "dateModified": "2021-12-11T11:50:13Z"
+        }
+    },
+    {
+        "key": "6EJ525KM",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6EJ525KM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6EJ525KM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Freeth",
+            "parsedDate": "2014-07-30",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Freeth, Tony. &#x201C;Eclipse Prediction on the Ancient Greek Astronomical Calculating Machine Known as the Antikythera Mechanism.&#x201D; <i>PLOS ONE</i>, vol. 9, no. 7, July 2014, p. e103275, https://doi.org/10/gmmk2k.</div>\n</div>",
+        "citation": "<span>(Freeth)</span>",
+        "data": {
+            "key": "6EJ525KM",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Eclipse Prediction on the Ancient Greek Astronomical Calculating Machine Known as the Antikythera Mechanism",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Tony",
+                    "lastName": "Freeth"
+                }
+            ],
+            "abstractNote": "The ancient Greek astronomical calculating machine, known as the Antikythera Mechanism, predicted eclipses, based on the 223-lunar month Saros cycle. Eclipses are indicated on a four-turn spiral Saros Dial by glyphs, which describe type and time of eclipse and include alphabetical index letters, referring to solar eclipse inscriptions. These include Index Letter Groups, describing shared eclipse characteristics. The grouping and ordering of the index letters, the organization of the inscriptions and the eclipse times have previously been unsolved. A new reading and interpretation of data from the back plate of the Antikythera Mechanism, including the glyphs, the index letters and the eclipse inscriptions, has resulted in substantial changes to previously published work. Based on these new readings, two arithmetical models are presented here that explain the complete eclipse prediction scheme. The first model solves the glyph distribution, the grouping and anomalous ordering of the index letters and the structure of the inscriptions. It also implies the existence of lost lunar eclipse inscriptions. The second model closely matches the glyph times and explains the four-turn spiral of the Saros Dial. Together, these models imply a surprisingly early epoch for the Antikythera Mechanism. The ancient Greeks built a machine that can predict, for many years ahead, not only eclipses but also a remarkable array of their characteristics, such as directions of obscuration, magnitude, colour, angular diameter of the Moon, relationship with the Moon’s node and eclipse time. It was not entirely accurate, but it was an astonishing achievement for its era.",
+            "publicationTitle": "PLOS ONE",
+            "volume": "9",
+            "issue": "7",
+            "pages": "e103275",
+            "date": "Jul 30, 2014",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "PLOS ONE",
+            "language": "en",
+            "DOI": "10/gmmk2k",
+            "ISSN": "1932-6203",
+            "shortTitle": "",
+            "url": "https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0103275",
+            "accessDate": "2021-04-18T22:20:41Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "PLoS Journals",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Public Library of Science",
+            "tags": [
+                {
+                    "tag": "Archaeology",
+                    "type": 1
+                },
+                {
+                    "tag": "Arithmetic",
+                    "type": 1
+                },
+                {
+                    "tag": "Astronomical instruments",
+                    "type": 1
+                },
+                {
+                    "tag": "Computed axial tomography",
+                    "type": 1
+                },
+                {
+                    "tag": "Greece",
+                    "type": 1
+                },
+                {
+                    "tag": "Latitude",
+                    "type": 1
+                },
+                {
+                    "tag": "Moons",
+                    "type": 1
+                },
+                {
+                    "tag": "X-ray radiography",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-04-18T22:20:41Z",
+            "dateModified": "2021-12-11T11:50:11Z"
+        }
+    },
+    {
+        "key": "S6ZQGI6J",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/S6ZQGI6J",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/S6ZQGI6J",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Edmunds",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Edmunds, M. G. &#x201C;The Antikythera Mechanism and the Mechanical Universe.&#x201D; <i>Contemporary Physics</i>, vol. 55, no. 4, 2014, pp. 263&#x2013;85, https://doi.org/10/gfvfsz.</div>\n</div>",
+        "citation": "<span>(Edmunds)</span>",
+        "data": {
+            "key": "S6ZQGI6J",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "The Antikythera mechanism and the mechanical universe",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "M. G.",
+                    "lastName": "Edmunds"
+                }
+            ],
+            "abstractNote": "How did our view of the Universe develop? By the mid-eighteenth century, a world view had developed of a system constrained by physical laws. These laws, if not entirely understood, showed regularity and could be handled mathematically to provide both explanation and prediction of celestial phenomena. Most of us have at least some hazy idea of the fundamental shift that came through the work of Copernicus, Kepler, Galileo and Newton. The idea of a ‘Mechanical Universe’ running rather like a clock tends to be associated with these sixteenth- and seventeenth-century pioneers. It remains a useful – and perhaps comforting – analogy. Yet, recent investigations based around the Antikythera Mechanism, an artefact from ancient Greece, reinforce a view that the ‘Mechanical’ conception has been around for a much longer time – indeed certainly as far back as the third century BC. The extent of mechanical design expertise existing around 100 BC as witnessed by the Antikythera Mechanism comes as a great surprise to most people. It is certainly a very ingenious device, often referred to as ‘The World’s First Computer’ although it is really a sophisticated mechanical astronomical calculator with its functions pre-determined rather than programmable. In this review, the structure and functions of the Antikythera Mechanism are described. The astronomy, cosmology and technology inherent in the machine fit surprisingly well into the context of its contemporary Classical world. A strong claim will be made for the influence of such mechanisms on the development of astronomical and philosophical views, based on literary reference. There is evidence that the technology persisted until its spectacular and rather sudden re-appearance in Western Europe around 1300 AD. From then on it is not hard to chart a path through the astronomical clocks of the sixteenth century to Kepler’s aim (expressed in a 1605 letter) to ‘show that the heavenly machine is not a kind of divine, live being, but a kind of clockwork …’, and on to the widespread development of popular visualisation of the heliocentric Solar System in the orreries of the eighteenth century.",
+            "publicationTitle": "Contemporary Physics",
+            "volume": "55",
+            "issue": "4",
+            "pages": "263-285",
+            "date": "2014",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gfvfsz",
+            "ISSN": "0010-7514",
+            "shortTitle": "",
+            "url": "https://doi.org/10.1080/00107514.2014.927280",
+            "accessDate": "2021-05-06T12:46:50Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Taylor and Francis+NEJM",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Taylor & Francis\n_eprint: https://doi.org/10.1080/00107514.2014.927280",
+            "tags": [
+                {
+                    "tag": "Corrigendum",
+                    "type": 1
+                },
+                {
+                    "tag": "History of Science",
+                    "type": 1
+                },
+                {
+                    "tag": "history of astronomy",
+                    "type": 1
+                },
+                {
+                    "tag": "history of cosmology",
+                    "type": 1
+                },
+                {
+                    "tag": "history of technology",
+                    "type": 1
+                },
+                {
+                    "tag": "mechanistic philosophy",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-05-06T12:46:50Z",
+            "dateModified": "2021-12-11T11:50:10Z"
+        }
+    },
+    {
+        "key": "ZUET4RGW",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ZUET4RGW",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ZUET4RGW",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Jones",
+            "parsedDate": "2015-01-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Jones, Alexander. &#x201C;The Astronomical Resources for Ancient Astral Prognostications.&#x201D; <i>The Star of Bethlehem and the Magi</i>, Jan. 2015, pp. 171&#x2013;98, https://doi.org/10/gnrdmt.</div>\n</div>",
+        "citation": "<span>(Jones)</span>",
+        "data": {
+            "key": "ZUET4RGW",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "The Astronomical Resources for Ancient Astral Prognostications",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                }
+            ],
+            "abstractNote": "The purpose of this chapter is to examine the astronomical knowledge, and more specifically the astronomical tools, that ancient astrologers in Mesopotamia and the Greco-Roman world possessed and used. Much of its content will be well known to specialists in ancient astronomy and astrology, but this is the first broad treatment of the topic. The roughly 1200-year evolution of astrological practice surveyed in this chapter is characterized by several shifts. First, interpretation of direct observations of the heavens was progressively supplanted by reliance on predicted astronomical data. Second, prediction based on the principle that astronomical phenomena observed in the past would approximately repeat after certain time intervals (called recurrence periods) gave way to mathematical models that had a more remote derivation from observations. Finally, astrologers became increasingly removed from the production of the astronomical information they used and increasingly dependent on published almanacs comprising precomputed data. This chapter is thus a contribution to understanding the expertise of an ancient astrologer as well as its limits.",
+            "publicationTitle": "The Star of Bethlehem and the Magi",
+            "volume": "",
+            "issue": "",
+            "pages": "171-198",
+            "date": "2015/01/01",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmt",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://brill.com/view/book/edcoll/9789004308473/B9789004308473_009.xml",
+            "accessDate": "2021-04-18T22:12:34Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "brill.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Brill\nSection: The Star of Bethlehem and the Magi",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-04-18T22:12:34Z",
+            "dateModified": "2021-12-11T11:50:10Z"
+        }
+    },
+    {
+        "key": "RQPL7P96",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/RQPL7P96",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/RQPL7P96",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Tolsa",
+            "parsedDate": "2018-11-27",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Tolsa, Cristian. &#x201C;The Table of Ptolemy&#x2019;s Terms (Tetr. 1.21).&#x201D; <i>Philologus</i>, vol. 162, no. 2, Nov. 2018, pp. 247&#x2013;64, https://doi.org/10/gnrdmw.</div>\n</div>",
+        "citation": "<span>(Tolsa)</span>",
+        "data": {
+            "key": "RQPL7P96",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "The Table of Ptolemy’s Terms (Tetr. 1.21)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Cristian",
+                    "lastName": "Tolsa"
+                }
+            ],
+            "abstractNote": "The paper presents three strong arguments advocating for the exclusion of the table of Ptolemy’s own planetary terms ( Tetr. 1.21.28–29) from the original text of the Tetrabiblos . This table was vastly used by Renaissance astrologers, and much work on its rationale and its manuscript variant readings has been published recently. The author argues that the table was the product of the systematic analysis of Ptolemy’s instructions for the terms in the late antique commentary on the Tetrabiblos edited by Wolf in 1559, and that it entered the direct transmission of Ptolemy’s text in the Byzantine period, probably in the 11 th century through cod. Laur. 28,34. The absence of the table in the original Tetrabiblos would explain Ptolemy’s recourse to a probably invented manuscript find and his limited account of the system’s workings.",
+            "publicationTitle": "Philologus",
+            "volume": "162",
+            "issue": "2",
+            "pages": "247-264",
+            "date": "2018/11/27",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "mul",
+            "DOI": "10/gnrdmw",
+            "ISSN": "2196-7008",
+            "shortTitle": "",
+            "url": "https://www.degruyter.com/document/doi/10.1515/phil-2017-0023/html",
+            "accessDate": "2021-04-17T13:05:08Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "www.degruyter.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: De Gruyter Akademie Forschung\nSection: Philologus",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/INRT7FVK"
+            },
+            "dateAdded": "2021-04-17T13:05:08Z",
+            "dateModified": "2021-12-11T11:50:09Z"
+        }
+    },
+    {
+        "key": "CJX4VLZI",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/CJX4VLZI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/CJX4VLZI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Steele",
+            "parsedDate": "2015",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Steele, John M. &#x201C;Late Babylonian Astrology.&#x201D; <i>Handbook of Archaeoastronomy and Ethnoastronomy</i>, 2015, pp. 1871&#x2013;75, https://doi.org/10/gnrdms.</div>\n</div>",
+        "citation": "<span>(Steele)</span>",
+        "data": {
+            "key": "CJX4VLZI",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Late Babylonian Astrology",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "John M.",
+                    "lastName": "Steele"
+                }
+            ],
+            "abstractNote": "The last five centuries BC saw the development of several new forms of astrology in Babylonia. Key to these new astrological techniques was the invention of the zodiac in about 400 BC. These new...",
+            "publicationTitle": "Handbook of Archaeoastronomy and Ethnoastronomy",
+            "volume": "",
+            "issue": "",
+            "pages": "1871-1875",
+            "date": "2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdms",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://link.springer.com.https.jxnydx.proxy.chaoxing.com/referenceworkentry/10.1007/978-1-4614-6141-8_193",
+            "accessDate": "2021-04-18T22:16:36Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "link.springer.com.https.jxnydx.proxy.chaoxing.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Springer, New York, NY",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/INRT7FVK"
+            },
+            "dateAdded": "2021-04-18T22:16:36Z",
+            "dateModified": "2021-12-11T11:50:09Z"
+        }
+    },
+    {
+        "key": "54KMI6CT",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/54KMI6CT",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/54KMI6CT",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Lawrence and Bodard",
+            "parsedDate": "2015-06-28",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Lawrence, K. Faith, and Gabriel Bodard. &#x201C;Prosopography Is Greek for Facebook: The SNAP:DRGN Project.&#x201D; <i>Proceedings of the ACM Web Science Conference</i>, Association for Computing Machinery, 2015, pp. 1&#x2013;2, https://doi.org/10/ggmxkf.</div>\n</div>",
+        "citation": "<span>(Lawrence and Bodard)</span>",
+        "data": {
+            "key": "54KMI6CT",
+            "version": 532,
+            "itemType": "conferencePaper",
+            "title": "Prosopography is Greek for Facebook: The SNAP:DRGN Project",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "K. Faith",
+                    "lastName": "Lawrence"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Gabriel",
+                    "lastName": "Bodard"
+                }
+            ],
+            "abstractNote": "In this paper, we present SNAP:DRGN, a pilot project intended to support Ancient World Linked Open Data through the creation of persistent identifiers for person and person-like entities. We introduce the linked data landscape as it exists with respect to the digitized Classical world and SNAP:DRGN's place within it.",
+            "date": "June 28, 2015",
+            "proceedingsTitle": "Proceedings of the ACM Web Science Conference",
+            "conferenceName": "",
+            "place": "New York, NY, USA",
+            "publisher": "Association for Computing Machinery",
+            "volume": "",
+            "pages": "1–2",
+            "series": "WebSci '15",
+            "language": "",
+            "DOI": "10/ggmxkf",
+            "ISBN": "978-1-4503-3672-7",
+            "shortTitle": "Prosopography is Greek for Facebook",
+            "url": "https://doi.org/10.1145/2786451.2786496",
+            "accessDate": "2021-04-17",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "ACM Digital Library",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "Classics",
+                    "type": 1
+                },
+                {
+                    "tag": "Prosopography",
+                    "type": 1
+                },
+                {
+                    "tag": "ancient history",
+                    "type": 1
+                },
+                {
+                    "tag": "open linked data",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T15:48:31Z",
+            "dateModified": "2021-12-11T11:50:08Z"
+        }
+    },
+    {
+        "key": "5BV7VE2Q",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5BV7VE2Q",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5BV7VE2Q",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Chen",
+            "parsedDate": "2021-03-19",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Chen, Anne Hunnell. &#x201C;Late Antiquity Between Sasanian East and Roman West: Third-Century Imperial Women as Pawns in Propaganda Warfare.&#x201D; <i>Late-Antique Studies in Memory of Alan Cameron</i>, Mar. 2021, pp. 168&#x2013;97, https://doi.org/10/gnrdmv.</div>\n</div>",
+        "citation": "<span>(Chen)</span>",
+        "data": {
+            "key": "5BV7VE2Q",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Late Antiquity Between Sasanian East and Roman West: Third-Century Imperial Women as Pawns in Propaganda Warfare",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Anne Hunnell",
+                    "lastName": "Chen"
+                }
+            ],
+            "abstractNote": "\"Chapter 9  Late Antiquity Between Sasanian East and Roman West\" published on 19 Mar 2021 by Brill.",
+            "publicationTitle": "Late-Antique Studies in Memory of Alan Cameron",
+            "volume": "",
+            "issue": "",
+            "pages": "168-197",
+            "date": "2021/03/19",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmv",
+            "ISSN": "",
+            "shortTitle": "Late Antiquity Between Sasanian East and Roman West",
+            "url": "https://brill.com/view/book/edcoll/9789004452794/BP000022.xml",
+            "accessDate": "2021-04-17T13:16:30Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "brill.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Brill\nSection: Late-Antique Studies in Memory of Alan Cameron",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-17T13:16:30Z",
+            "dateModified": "2021-12-11T11:50:08Z"
+        }
+    },
+    {
+        "key": "B3C4IUZ7",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/B3C4IUZ7",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/B3C4IUZ7",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Simon et al.",
+            "parsedDate": "2017-01-02",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Simon, Rainer, et al. &#x201C;Linked Data Annotation Without the Pointy Brackets: Introducing Recogito 2.&#x201D; <i>Journal of Map &amp; Geography Libraries</i>, vol. 13, no. 1, Jan. 2017, pp. 111&#x2013;32, https://doi.org/10/gf7454.</div>\n</div>",
+        "citation": "<span>(Simon et al.)</span>",
+        "data": {
+            "key": "B3C4IUZ7",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Linked Data Annotation Without the Pointy Brackets: Introducing Recogito 2",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rainer",
+                    "lastName": "Simon"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Elton",
+                    "lastName": "Barker"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Leif",
+                    "lastName": "Isaksen"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Pau De Soto",
+                    "lastName": "CaÑamares"
+                }
+            ],
+            "abstractNote": "Recogito 2 is an open source annotation tool currently under development by Pelagios, an international initiative aimed at facilitating better linkages between online resources documenting the past. With Recogito 2, we aim to provide an environment for efficient semantic annotation—i.e., the task of enriching content with references to controlled vocabularies—in order to facilitate links between online data. At the same time, we address a perceived gap in the performance of existing tools, by emphasizing the development of mechanisms for manual intervention and editorial control that support the curation of quality data. While Recogito 2 provides an online workspace for general-purpose document annotation, it is particularly well-suited for geo-annotation, in other words annotating documents with references to gazetteers, and supports the annotation of both texts and images (i.e., digitized maps). Already available for testing at http://recogito.pelagios.org, its formal release to the public occurred in December 2016.",
+            "publicationTitle": "Journal of Map & Geography Libraries",
+            "volume": "13",
+            "issue": "1",
+            "pages": "111-132",
+            "date": "January 2, 2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gf7454",
+            "ISSN": "1542-0353",
+            "shortTitle": "Linked Data Annotation Without the Pointy Brackets",
+            "url": "https://doi.org/10.1080/15420353.2017.1307303",
+            "accessDate": "2021-04-17T15:57:15Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Taylor and Francis+NEJM",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Routledge\n_eprint: https://doi.org/10.1080/15420353.2017.1307303",
+            "tags": [
+                {
+                    "tag": "annotation",
+                    "type": 1
+                },
+                {
+                    "tag": "digital humanities",
+                    "type": 1
+                },
+                {
+                    "tag": "gazetteers",
+                    "type": 1
+                },
+                {
+                    "tag": "georeferencing",
+                    "type": 1
+                },
+                {
+                    "tag": "linked data",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/T79TMG8G",
+                    "http://zotero.org/groups/242005/items/HMZ4FRKN",
+                    "http://zotero.org/groups/242005/items/9USWD24D"
+                ]
+            },
+            "dateAdded": "2021-04-17T15:57:15Z",
+            "dateModified": "2021-12-11T11:50:08Z"
+        }
+    },
+    {
+        "key": "VMKQ9NFK",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VMKQ9NFK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VMKQ9NFK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hoyer",
+            "parsedDate": "2013-09-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hoyer, Daniel. &#x201C;Public Feasting, Elite Competition, and the Market Economy of Roman North Africa.&#x201D; <i>The Journal of North African Studies</i>, vol. 18, no. 4, Sept. 2013, pp. 574&#x2013;91, https://doi.org/10/gnrdm3.</div>\n</div>",
+        "citation": "<span>(Hoyer)</span>",
+        "data": {
+            "key": "VMKQ9NFK",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Public feasting, elite competition, and the market economy of Roman North Africa",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Daniel",
+                    "lastName": "Hoyer"
+                }
+            ],
+            "abstractNote": "This article explores the economy of Roman North Africa, particularly the province of Africa Proconsularis, in an attempt to illuminate how the area grew to become one of the most prosperous areas of the Roman Empire. Looking specifically at the institutional role played by competitive, ostentatious spending on public goods by elites in the region, I contend that this elite competition and the money this injected into the regional economy was a major factor in the development of market forces and monetisation throughout Roman Africa. Further, this perspective helps to explain also how the urban spaces and the agriculturally productive rural areas of Roman Africa were linked together, forming an active regional economy that operated alongside, and partly in competition with, the export-oriented economy focused on supplying the city Rome.",
+            "publicationTitle": "The Journal of North African Studies",
+            "volume": "18",
+            "issue": "4",
+            "pages": "574-591",
+            "date": "September 1, 2013",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdm3",
+            "ISSN": "1362-9387",
+            "shortTitle": "",
+            "url": "https://doi.org/10.1080/13629387.2013.822304",
+            "accessDate": "2021-04-16T12:10:37Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Taylor and Francis+NEJM",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Routledge\n_eprint: https://doi.org/10.1080/13629387.2013.822304",
+            "tags": [
+                {
+                    "tag": "Africa proconsularis",
+                    "type": 1
+                },
+                {
+                    "tag": "Rome",
+                    "type": 1
+                },
+                {
+                    "tag": "benefaction",
+                    "type": 1
+                },
+                {
+                    "tag": "competition",
+                    "type": 1
+                },
+                {
+                    "tag": "elite",
+                    "type": 1
+                },
+                {
+                    "tag": "feasting",
+                    "type": 1
+                },
+                {
+                    "tag": "marketisation",
+                    "type": 1
+                },
+                {
+                    "tag": "monetisation",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-16T12:10:37Z",
+            "dateModified": "2021-12-11T11:50:07Z"
+        }
+    },
+    {
+        "key": "6DAWH9QK",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/6DAWH9QK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/6DAWH9QK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Simon et al.",
+            "parsedDate": "2015",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Simon, Rainer, et al. &#x201C;Linking Early Geospatial Documents, One Place at a Time: Annotation of Geographic Documents with Recogito.&#x201D; <i>E-Perimetron</i>, vol. 10, no. 2, 2015, pp. 49&#x2013;59.</div>\n</div>",
+        "citation": "<span>(Simon et al.)</span>",
+        "data": {
+            "key": "6DAWH9QK",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Linking Early Geospatial Documents, One Place at a Time: Annotation of Geographic Documents with Recogito",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Rainer",
+                    "lastName": "Simon"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Elton",
+                    "lastName": "Barker"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Leif",
+                    "lastName": "Isaksen"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Soto",
+                    "lastName": "Cañamares"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "e-Perimetron",
+            "volume": "10",
+            "issue": "2",
+            "pages": "49-59",
+            "date": "2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "1790-3769",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/T79TMG8G",
+                    "http://zotero.org/groups/242005/items/9USWD24D"
+                ]
+            },
+            "dateAdded": "2021-05-03T14:03:48Z",
+            "dateModified": "2021-12-11T11:50:07Z"
+        }
+    },
+    {
+        "key": "EFUYM4Q9",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/EFUYM4Q9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/EFUYM4Q9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bagnall and Heath",
+            "parsedDate": "2018-11",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bagnall, Roger S., and Sebastian Heath. &#x201C;Roman Studies and Digital Resources.&#x201D; <i>The Journal of Roman Studies</i>, vol. 108, Nov. 2018, pp. 171&#x2013;89, https://doi.org/10/gfgj7s.</div>\n</div>",
+        "citation": "<span>(Bagnall and Heath)</span>",
+        "data": {
+            "key": "EFUYM4Q9",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Roman Studies and Digital Resources",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Roger S.",
+                    "lastName": "Bagnall"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                }
+            ],
+            "abstractNote": "There is hardly any aspect of scholarly work and teaching in Roman Studies today not marked by digital technology. We assume that readers regularly access digital images of Roman material culture, use digitised corpora of primary sources in the original language or translation or consult online books and articles. The availability of digital resources on the internet is also a welcome enabler of ongoing public interest and even participation in the field. This overall state of affairs is generally a positive development, but both general trends and specific digital resources deserve a critical appraisal.",
+            "publicationTitle": "The Journal of Roman Studies",
+            "volume": "108",
+            "issue": "",
+            "pages": "171-189",
+            "date": "2018/11",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gfgj7s",
+            "ISSN": "0075-4358, 1753-528X",
+            "shortTitle": "",
+            "url": "https://www.cambridge.org/core/journals/journal-of-roman-studies/article/abs/roman-studies-and-digital-resources/D565703075B03A3F45A5FEE4DF608788",
+            "accessDate": "2021-04-15T22:29:38Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Cambridge University Press",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Cambridge University Press",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-15T22:29:38Z",
+            "dateModified": "2021-12-11T11:50:06Z"
+        }
+    },
+    {
+        "key": "5XC5S76H",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5XC5S76H",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5XC5S76H",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bodel et al.",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bodel, John, et al. &#x201C;Notes on the Elogium of a Benefactor at Pompeii.&#x201D; <i>Journal of Roman Archaeology</i>, vol. 32, ed 2019, pp. 148&#x2013;82, https://doi.org/10/gnrdm2.</div>\n</div>",
+        "citation": "<span>(Bodel et al.)</span>",
+        "data": {
+            "key": "5XC5S76H",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Notes on the elogium of a benefactor at Pompeii",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Bodel"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andreas",
+                    "lastName": "Bendlin"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Seth",
+                    "lastName": "Bernard"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christer",
+                    "lastName": "Bruun"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Jonathan",
+                    "lastName": "Edmondson"
+                }
+            ],
+            "abstractNote": "The rediscovery in the summer of 2017 of a large monumental tomb of unusual form outside the Stabian Gate at Pompeii caused an immediate sensation, and the swift initial publication by M. Osanna in JRA 31 (2018) of the long funerary inscription fronting the W side of the base, facing the road, has been welcomed gratefully by the scholarly community. The text — at 183 words, by far the longest funerary inscription yet found at Pompeii — records a series of extraordinary benefactions by an unnamed local worthy, beginning with a banquet held on the occasion of his coming-of-age ceremony and continuing, it seems, well into his adult life, up to the final years of the town when the monument was built. As Osanna and others have recognized, the inscription, which seems to allude to an historical event (Tac., Ann. 14.17), the riot between Nucerians and Pompeians around Pompeii’s amphitheater in A.D. 59, provides valuable if ambivalent new information relevant to the demographic, economic and social history of Pompeii that will require full discussion in a variety of contexts over time. The present collection of remarks, a collaborative effort, is offered in the spirit of debate and is intended as an interim contribution toward a more complete understanding of the text.1",
+            "publicationTitle": "Journal of Roman Archaeology",
+            "volume": "32",
+            "issue": "",
+            "pages": "148-182",
+            "date": "2019/ed",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdm2",
+            "ISSN": "1047-7594, 2331-5709",
+            "shortTitle": "",
+            "url": "https://www.cambridge.org/core/journals/journal-of-roman-archaeology/article/abs/notes-on-the-elogium-of-a-benefactor-at-pompeii/D81465F4C8FB7298950682143FB2585D",
+            "accessDate": "2021-04-16T13:08:52Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Cambridge University Press",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Journal of Roman Archaeology L.L.C.",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-16T13:08:52Z",
+            "dateModified": "2021-12-11T11:50:06Z"
+        }
+    },
+    {
+        "key": "S5HYJC4E",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/S5HYJC4E",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/S5HYJC4E",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Saint-Laurent",
+            "parsedDate": "2016-12-06",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Saint-Laurent, Jeanne-Nicole Mellon. &#x201C;Gateway to the Syriac Saints: A Database Project.&#x201D; <i>Journal of Religion, Media and Digital Culture</i>, vol. 5, no. 1, Dec. 2016, pp. 183&#x2013;204, https://doi.org/10/gnrdmz.</div>\n</div>",
+        "citation": "<span>(Saint-Laurent)</span>",
+        "data": {
+            "key": "S5HYJC4E",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Gateway to the Syriac Saints: A Database Project",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Jeanne-Nicole Mellon",
+                    "lastName": "Saint-Laurent"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Journal of Religion, Media and Digital Culture",
+            "volume": "5",
+            "issue": "1",
+            "pages": "183-204",
+            "date": "2016/12/06",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmz",
+            "ISSN": "2165-9214, 2588-8099",
+            "shortTitle": "Gateway to the Syriac Saints",
+            "url": "https://brill.com/view/journals/rmdc/5/1/article-p183_183.xml",
+            "accessDate": "2021-04-17T12:58:24Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "brill.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Brill\nSection: Journal of Religion, Media and Digital Culture",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T12:58:24Z",
+            "dateModified": "2021-12-11T11:50:05Z"
+        }
+    },
+    {
+        "key": "A8C5RSXP",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/A8C5RSXP",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/A8C5RSXP",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Leonard and Bond",
+            "parsedDate": "2019-03-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Leonard, Victoria, and Sarah E. Bond. &#x201C;Advancing Feminism Online: Online Tools, Visibility, and Women in Classics.&#x201D; <i>Studies in Late Antiquity</i>, vol. 3, no. 1, Mar. 2019, pp. 4&#x2013;16, https://doi.org/10/gf72h7.</div>\n</div>",
+        "citation": "<span>(Leonard and Bond)</span>",
+        "data": {
+            "key": "A8C5RSXP",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Advancing Feminism Online: Online Tools, Visibility, and Women in Classics",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Victoria",
+                    "lastName": "Leonard"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Sarah E.",
+                    "lastName": "Bond"
+                }
+            ],
+            "abstractNote": "Can online tools address gender bias in classics? Through two case studies, this article explores the use of crowd-sourcing in order to develop digital tools that amplify women and provide them with a firmer online identity. The first, Wikipedia.org, is already entrenched in the popular research realm, and the second, WOAH (Women of Ancient History), is currently being developed as a reference tool. Wikipedia.org is the most influential source of knowledge in the world, but it has a stubborn gender bias against women. This distortion is particularly evident in the field of classics, where prior to 2017 only 7% of biographies of classicists featured women. Here, ‘classics’ is an inclusive term, and is broadly conceived to include the field of Late Antiquity. This short article details how the Women's Classical Committee (UK)'s Wikipedia editing initiative, #WCCWiki, and the development of WOAH, have successfully increased the visibility of women online. Consequently, it offers a model to mobilize change with few physical or financial resources, but rather facilitated by digital tools and social media. Through digital feminist activism, there is the potential to reverse the gender skew of classicists online and in the public discourse, while also creating an inclusive space that is professional, proactive, and accessible to all.",
+            "publicationTitle": "Studies in Late Antiquity",
+            "volume": "3",
+            "issue": "1",
+            "pages": "4-16",
+            "date": "2019/03/01",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "Studies in Late Antiquity",
+            "language": "en",
+            "DOI": "10/gf72h7",
+            "ISSN": "2470-6469",
+            "shortTitle": "",
+            "url": "/SLA/article/3/1/4/83368/Advancing-Feminism-OnlineOnline-Tools-Visibility",
+            "accessDate": "2021-04-17T12:45:34Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "online.ucpress.edu",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: University of California Press",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T12:45:34Z",
+            "dateModified": "2021-12-11T11:50:05Z"
+        }
+    },
+    {
+        "key": "DLDDXZ5Z",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/DLDDXZ5Z",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/DLDDXZ5Z",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Roosevelt et al.",
+            "parsedDate": "2015-06-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Roosevelt, Christopher H., et al. &#x201C;Excavation Is Destruction Digitization: Advances in Archaeological Practice.&#x201D; <i>Journal of Field Archaeology</i>, vol. 40, no. 3, June 2015, pp. 325&#x2013;46, https://doi.org/10/gd598d.</div>\n</div>",
+        "citation": "<span>(Roosevelt et al.)</span>",
+        "data": {
+            "key": "DLDDXZ5Z",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Excavation is Destruction Digitization: Advances in Archaeological Practice",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christopher H.",
+                    "lastName": "Roosevelt"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Peter",
+                    "lastName": "Cobb"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Emanuel",
+                    "lastName": "Moss"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Brandon R.",
+                    "lastName": "Olson"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Sinan",
+                    "lastName": "Ünlüsoy"
+                }
+            ],
+            "abstractNote": "This article modifies an old archaeological adage—“excavation is destruction”—to demonstrate how advances in archaeological practice suggest a new iteration: “excavation is digitization.” Digitization, in a fully digital paradigm, refers to practices that leverage advances in onsite, image-based modeling and volumetric recording, integrated databases, and data sharing. Such practices were implemented in 2014 during the inaugural season of the Kaymakçı Archaeological Project (KAP) in western Turkey. The KAP recording system, developed from inception before excavation as a digital workflow, increases accuracy and efficiency as well as simplicity and consistency. The system also encourages both practical and conceptual advances in archaeological practice. These involve benefits associated with thinking volumetrically, rather than in two dimensions, and a connectivity that allows for group decision-making regardless of group location. Additionally, it is hoped that the system's use of almost entirely “off-the-shelf” solutions will encourage its adoption or at least its imitation by other projects.",
+            "publicationTitle": "Journal of Field Archaeology",
+            "volume": "40",
+            "issue": "3",
+            "pages": "325-346",
+            "date": "June 1, 2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gd598d",
+            "ISSN": "0093-4690",
+            "shortTitle": "Excavation is Destruction Digitization",
+            "url": "https://doi.org/10.1179/2042458215Y.0000000004",
+            "accessDate": "2021-04-17T12:39:31Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Taylor and Francis+NEJM",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Routledge\n_eprint: https://doi.org/10.1179/2042458215Y.0000000004",
+            "tags": [
+                {
+                    "tag": "Kaymakçı Archaeological Project (Turkey)",
+                    "type": 1
+                },
+                {
+                    "tag": "digital culture",
+                    "type": 1
+                },
+                {
+                    "tag": "image-based modeling",
+                    "type": 1
+                },
+                {
+                    "tag": "integrated spatial database management",
+                    "type": 1
+                },
+                {
+                    "tag": "volumetric (3D) recording",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T12:40:01Z",
+            "dateModified": "2021-12-11T11:50:05Z"
+        }
+    },
+    {
+        "key": "QSPWYCMK",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QSPWYCMK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QSPWYCMK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Chen and Fulsom",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Chen, Anne Hunnel, and Jamie Fulsom. &#x201C;Origins and Antidotes of Omission: Southeastern European Archaeology, Linked Open Data, and the Possibilities for Archaeological Integration.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 12, 2021, http://hdl.handle.net/2333.1/xsj3v7j6.</div>\n</div>",
+        "citation": "<span>(Chen and Fulsom)</span>",
+        "data": {
+            "key": "QSPWYCMK",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Origins and Antidotes of Omission: Southeastern European Archaeology, Linked Open Data, and the Possibilities for Archaeological Integration",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Anne Hunnel",
+                    "lastName": "Chen"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Jamie",
+                    "lastName": "Fulsom"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "12",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/xsj3v7j6",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:09:33Z",
+            "dateModified": "2021-12-11T11:50:04Z"
+        }
+    },
+    {
+        "key": "5QRUQUXS",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5QRUQUXS",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5QRUQUXS",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Taras and Šelendić",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Taras, Dino, and Ines &#x160;elendi&#x107;. &#x201C;Kaprije 3 &#x2013; a Late Antiquity Shipwreck Off the Island of Kaprije.&#x201D; <i>Diadora&#x202F;: Journal of the Archaeological Museum in Zadar</i>, vol. 33&#x2013;34, 2020, pp. 317&#x2013;446, https://hrcak.srce.hr/237162.</div>\n</div>",
+        "citation": "<span>(Taras and Šelendić)</span>",
+        "data": {
+            "key": "5QRUQUXS",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Kaprije 3 – a Late Antiquity Shipwreck Off the Island of Kaprije",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Dino",
+                    "lastName": "Taras"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ines",
+                    "lastName": "Šelendić"
+                }
+            ],
+            "abstractNote": "The authors have analyzed the archaeological finds from a Late Antiquity shipwreck off the coast of the island of Kaprije. The finds – that mostly include amphorae – have been scientifically analyzed and dated, thus helping establish the time of the ship­wreck. Other pottery and the elements of the ship’s hull were found in the quantities that do not allow more precise dating based on specific shapes and analogies.",
+            "publicationTitle": "Diadora : journal of the Archaeological Museum in Zadar",
+            "volume": "33-34",
+            "issue": "",
+            "pages": "317-446",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://hrcak.srce.hr/237162",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-04-15T22:36:30Z",
+            "dateModified": "2021-12-11T11:50:03Z"
+        }
+    },
+    {
+        "key": "WVB5DW37",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WVB5DW37",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WVB5DW37",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "László",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">L&#xE1;szl&#xF3;, Levente. &#x201C;Rhetorius, Zeno&#x2019;s Astrologer, and a Sixth-Century Astrological Compendium.&#x201D; <i>Dumbarton Oaks Papers</i>, vol. 74, 2020, pp. 329&#x2013;50, https://www.jstor.org/stable/26979088.</div>\n</div>",
+        "citation": "<span>(László)</span>",
+        "data": {
+            "key": "WVB5DW37",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Rhetorius, Zeno’s Astrologer, and a Sixth-Century Astrological Compendium",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Levente",
+                    "lastName": "László"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Dumbarton Oaks Papers",
+            "volume": "74",
+            "issue": "",
+            "pages": "329-350",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "0070-7546",
+            "shortTitle": "",
+            "url": "https://www.jstor.org/stable/26979088",
+            "accessDate": "2021-04-15T18:23:17Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "JSTOR",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Dumbarton Oaks, Trustees for Harvard University",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5A46BUSX"
+            },
+            "dateAdded": "2021-04-15T18:23:17Z",
+            "dateModified": "2021-12-11T11:50:03Z"
+        }
+    },
+    {
+        "key": "JC8QMZTU",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/JC8QMZTU",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/JC8QMZTU",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "De Romanis",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">De Romanis, Federico. &#x201C;Ivory from Muziris.&#x201D; <i>ISAW Papers</i>, vol. 8, 2014, https://hdl.handle.net/2333.1/p5hqc1c7.</div>\n</div>",
+        "citation": "<span>(De Romanis)</span>",
+        "data": {
+            "key": "JC8QMZTU",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "Ivory from Muziris",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Federico",
+                    "lastName": "De Romanis"
+                }
+            ],
+            "abstractNote": "The extant portion of the verso side of the “Muziris papyrus” (PVindob G 40822 v = SB XVIII 13617 v) contains the monetary evaluation of three-quarters of an Indian cargo loaded on the ship Hermapollon. Among the commodities are 167 elephant tusks weighing 3,228.5 kgs and schidai weighing 538.5 kgs. It is argued that schidai are fragments of tusks trimmed away from captive elephants. A comparison with commercial ivory lots of the early sixteenth century shows the selected quality of the tusks loaded on the Hermapollon.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "8",
+            "issue": "",
+            "pages": "",
+            "date": "2014",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://hdl.handle.net/2333.1/p5hqc1c7",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "CC-BY",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HWDF8YP5"
+            },
+            "dateAdded": "2014-07-16T14:08:04Z",
+            "dateModified": "2021-12-11T11:50:03Z"
+        }
+    },
+    {
+        "key": "WQXYJU4U",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WQXYJU4U",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WQXYJU4U",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Mitchell",
+            "parsedDate": "2015-12-17",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Mitchell, Erik T. &#x201C;Applied Systems, Vocabularies, and Standards.&#x201D; <i>Library Technology Reports</i>, vol. 52, no. 1, Dec. 2015, pp. 22&#x2013;28, https://journals.ala.org/index.php/ltr/article/view/5894.</div>\n</div>",
+        "citation": "<span>(Mitchell)</span>",
+        "data": {
+            "key": "WQXYJU4U",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Applied Systems, Vocabularies, and Standards",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Erik T.",
+                    "lastName": "Mitchell"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Library Technology Reports",
+            "volume": "52",
+            "issue": "1",
+            "pages": "22-28",
+            "date": "2015/12/17",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "",
+            "ISSN": "0024-2586",
+            "shortTitle": "",
+            "url": "https://journals.ala.org/index.php/ltr/article/view/5894",
+            "accessDate": "2021-04-17T12:51:07Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "Copyright (c) 2015 American Library Association",
+            "extra": "Number: 1",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/7NNJCWG9"
+            },
+            "dateAdded": "2021-04-17T12:51:07Z",
+            "dateModified": "2021-12-11T11:50:03Z"
+        }
+    },
+    {
+        "key": "IG5FSTMD",
+        "version": 533,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IG5FSTMD",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IG5FSTMD",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Carman and Di Cocco",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Carman, Christi&#xE1;n, and Marcelo Di Cocco. &#x201C;The Moon Phase Anomaly in the Antikythera Mechanism.&#x201D; <i>ISAW Papers</i>, vol. 11, 2016, http://doi.org/2333.1/3ffbgd1v.</div>\n</div>",
+        "citation": "<span>(Carman and Di Cocco)</span>",
+        "data": {
+            "key": "IG5FSTMD",
+            "version": 533,
+            "itemType": "journalArticle",
+            "title": "The Moon Phase Anomaly in the Antikythera Mechanism",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christián",
+                    "lastName": "Carman"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Marcelo",
+                    "lastName": "Di Cocco"
+                }
+            ],
+            "abstractNote": "The Antikythera Mechanism is a mechanical astronomical instrument that was discovered in an ancient shipwreck at the beginning of the twentieth century, made about the second century B.C. It had several pointers showing the positions of the moon and sun in the zodiac, the approximate date according to a lunisolar calendar, several subsidiary dials showing calendrical phenomena, and also predictions of eclipses. The mechanism also had a display of the Moon’s phases: a small ball, half pale and half dark, rotating with the lunar synodic period and so showing the phases of the moon. The remains of the moon phase display include a fragmentary contrate gear. According to the reconstruction offered by Michael Wright, this gear is now pointing unintentionally in the wrong direction. In this paper we offer for the first time a detailed description of the remains of the moon phase mechanism. Based on this evidence, we argue that the extant contrate gear direction is the originally intended one, and we offer a conjectural explanation for its direction as an essential part of a representation of Aristarchus’s hypothesis that half moon phase is observably displaced from exact quadrature.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "11",
+            "issue": "",
+            "pages": "",
+            "date": "2016",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://doi.org/2333.1/3ffbgd1v",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/KUYAWYLM",
+                    "http://zotero.org/groups/242005/items/BX475BJC"
+                ]
+            },
+            "dateAdded": "2016-04-28T16:42:53Z",
+            "dateModified": "2021-12-11T11:50:02Z"
+        }
+    },
+    {
+        "key": "PIB52KQG",
+        "version": 532,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/PIB52KQG",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/PIB52KQG",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Michelson",
+            "parsedDate": "2016-12-06",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Michelson, David A. &#x201C;Mixed Up by Time and Chance? Using Digital Methods to &#x2018;Re-Orient&#x2019; the Syriac Religious Literature of Late Antiquity.&#x201D; <i>Journal of Religion, Media and Digital Culture</i>, vol. 5, no. 1, Dec. 2016, pp. 136&#x2013;82, https://doi.org/10/gnrdmx.</div>\n</div>",
+        "citation": "<span>(Michelson)</span>",
+        "data": {
+            "key": "PIB52KQG",
+            "version": 532,
+            "itemType": "journalArticle",
+            "title": "Mixed Up by Time and Chance? Using Digital Methods to “Re-Orient” the Syriac Religious Literature of Late Antiquity",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "David A.",
+                    "lastName": "Michelson"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Journal of Religion, Media and Digital Culture",
+            "volume": "5",
+            "issue": "1",
+            "pages": "136-182",
+            "date": "2016/12/06",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmx",
+            "ISSN": "2165-9214, 2588-8099",
+            "shortTitle": "Mixed Up by Time and Chance?",
+            "url": "https://brill.com/view/journals/rmdc/5/1/article-p136_136.xml",
+            "accessDate": "2021-04-17T13:00:16Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "brill.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Brill\nSection: Journal of Religion, Media and Digital Culture",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-04-17T13:00:16Z",
+            "dateModified": "2021-12-11T11:50:01Z"
+        }
+    },
+    {
+        "key": "J5IPIFXX",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/J5IPIFXX",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/J5IPIFXX",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Izdebski et al.",
+            "parsedDate": "2020-11-23",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Izdebski, Adam, et al. &#x201C;Landscape Change and Trade in Ancient Greece: Evidence from Pollen Data.&#x201D; <i>The Economic Journal</i>, vol. 130, no. 632, Nov. 2020, pp. 2596&#x2013;618, https://doi.org/10/gjfn42.</div>\n</div>",
+        "citation": "<span>(Izdebski et al.)</span>",
+        "data": {
+            "key": "J5IPIFXX",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Landscape Change and Trade in Ancient Greece: Evidence from Pollen Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Adam",
+                    "lastName": "Izdebski"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Tymon",
+                    "lastName": "Słoczyński"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Anton",
+                    "lastName": "Bonnier"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Grzegorz",
+                    "lastName": "Koloch"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Katerina",
+                    "lastName": "Kouli"
+                }
+            ],
+            "abstractNote": "In this article we use pollen data from six sites in southern Greece to study long-term vegetation change in this region from 1000 BCE to 600 CE. Based on insights from environmental history, we interpret our estimated trends in the regional presence of cereal, olive and vine pollen as proxies for structural changes in agricultural production. We present evidence that there was a market economy in ancient Greece and a major trade expansion several centuries before the Roman conquest. Our results are consistent with auxiliary data on settlement dynamics, shipwrecks and ancient oil and wine presses.",
+            "publicationTitle": "The Economic Journal",
+            "volume": "130",
+            "issue": "632",
+            "pages": "2596-2618",
+            "date": "November 23, 2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "The Economic Journal",
+            "language": "",
+            "DOI": "10/gjfn42",
+            "ISSN": "0013-0133",
+            "shortTitle": "Landscape Change and Trade in Ancient Greece",
+            "url": "https://doi.org/10.1093/ej/ueaa026",
+            "accessDate": "2021-04-18T14:57:49Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-18T14:57:49Z",
+            "dateModified": "2021-12-11T11:50:01Z"
+        }
+    },
+    {
+        "key": "DNTFILSI",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/DNTFILSI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/DNTFILSI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Palladino",
+            "parsedDate": "2016",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Palladino, Chiara. &#x201C;New Approaches to Ancient Spatial Models: Digital Humanities and Classical Geography.&#x201D; <i>Bulletin of the Institute of Classical Studies</i>, vol. 59, no. 2, 2016, pp. 56&#x2013;70, https://doi.org/10/gmd56v.</div>\n</div>",
+        "citation": "<span>(Palladino)</span>",
+        "data": {
+            "key": "DNTFILSI",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "New Approaches to Ancient Spatial Models: Digital Humanities and Classical Geography",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Chiara",
+                    "lastName": "Palladino"
+                }
+            ],
+            "abstractNote": "This paper proposes a methodology to address the problem of the representation of Greek and Roman geography in the digital environment. As classical geography was not only a graphic representation of the world, but a multi-layered cultural system based on specific notions and concepts, it is now necessary to go beyond the taxonomy of place-names and their visualization on modern maps. The interpretation of ancient geography as a ‘mental model’ implies the importance of different and complementary aspects which should be addressed systematically: the expression of distances, the language of spatial orientation, the definition of environmental landmarks. For each of these aspects an integrated digital methodology is proposed, either implementing existing infrastructures or focusing on new strategies. The conclusion establishes a workflow to be tested on the corpus of the Geographi Graeci Minores, and extended to a variety of other texts.",
+            "publicationTitle": "Bulletin of the Institute of Classical Studies",
+            "volume": "59",
+            "issue": "2",
+            "pages": "56-70",
+            "date": "2016",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gmd56v",
+            "ISSN": "2041-5370",
+            "shortTitle": "New Approaches to Ancient Spatial Models",
+            "url": "https://onlinelibrary.wiley.com/doi/abs/10.1111/j.2041-5370.2016.12038.x",
+            "accessDate": "2021-05-06T14:26:40Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Wiley Online Library",
+            "callNumber": "",
+            "rights": "© 2016 Institute of Classical Studies University of London",
+            "extra": "_eprint: https://onlinelibrary.wiley.com/doi/pdf/10.1111/j.2041-5370.2016.12038.x",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/BDGLCS9T",
+                    "http://zotero.org/groups/242005/items/RSR6AP3D"
+                ]
+            },
+            "dateAdded": "2021-05-06T14:26:40Z",
+            "dateModified": "2021-12-11T11:50:00Z"
+        }
+    },
+    {
+        "key": "THVV3TGW",
+        "version": 531,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/THVV3TGW",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/THVV3TGW",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Kalligas",
+            "parsedDate": "2016-12-15",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Kalligas, Paul. &#x201C;Platonic Astronomy and the Development of Ancient Sphairopoiia.&#x201D; <i>Rhizomata</i>, vol. 4, no. 2, Dec. 2016, pp. 176&#x2013;200, https://doi.org/10/gnrdmr.</div>\n</div>",
+        "citation": "<span>(Kalligas)</span>",
+        "data": {
+            "key": "THVV3TGW",
+            "version": 531,
+            "itemType": "journalArticle",
+            "title": "Platonic Astronomy and the Development of Ancient Sphairopoiia",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Kalligas"
+                }
+            ],
+            "abstractNote": "Plato’s views on astronomy are still somehow debated, however various scholars have associated his name with the project of “saving the appearances”, which is thought to have aimed at offering a precise geometrical account of celestial motions. A passage from Theon of Smyrna’s treatise on Platonic mathematics relates this project with the construction of mechanical models of the cosmos. New information deriving from the study of the so-called Antikythera mechanism, found nearly 100 years ago in an ancient shipwreck in the Aegean, seems to provide important technical evidence illustrating the evolution of this endeavour during the Hellenistic period.",
+            "publicationTitle": "Rhizomata",
+            "volume": "4",
+            "issue": "2",
+            "pages": "176-200",
+            "date": "2016/12/15",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmr",
+            "ISSN": "2196-5110",
+            "shortTitle": "",
+            "url": "https://www.degruyter.com/document/doi/10.1515/rhiz-2016-0010/html",
+            "accessDate": "2021-04-18T22:18:56Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "www.degruyter.com",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: De Gruyter\nSection: Rhizomata",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VQDAMNGH"
+            },
+            "dateAdded": "2021-04-18T22:18:56Z",
+            "dateModified": "2021-12-11T11:50:00Z"
+        }
+    },
+    {
+        "key": "BX475BJC",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/BX475BJC",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/BX475BJC",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Voulgaris et al.",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Voulgaris, Aristeidis, et al. &#x201C;The new findings from Antikythera mechanism front plate astronomical dial and its reconstruction.&#x201D; <i>Archeomatica</i>, vol. 8, no. 5, 2017, https://doi.org/10.48258/arc.v8i5.1667.</div>\n</div>",
+        "citation": "<span>(Voulgaris et al.)</span>",
+        "data": {
+            "key": "BX475BJC",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "The new findings from Antikythera mechanism front plate astronomical dial and its reconstruction",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Aristeidis",
+                    "lastName": "Voulgaris"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andreas",
+                    "lastName": "Vossinakis"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christophoros",
+                    "lastName": "Mouratidis"
+                }
+            ],
+            "abstractNote": "The present study aims to investigate the astronomical calendar-dialdisplay of the Antikythera Mechanism Front Plate. The design, positionand role of the Zodiac ring, are investigated and discussed. Specialphotographs taken from the ancient prototype, give us new informationabout the design and operation of the front dial. From thesenew findings about the Zodiac ring, we conclude that the user of themechanism was able to easily perform astronomical calculations atany selected time - of past or future date. Based on the new findingsduring ‘’The Functional Reconstruction of Antikythera MechanismProject’’ (FRAMe), we reconstructed the new bronze front plate andwe placed it in our functional model of the Antikythera Mechanism.",
+            "publicationTitle": "Archeomatica",
+            "volume": "8",
+            "issue": "5",
+            "pages": "",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "it",
+            "DOI": "10.48258/arc.v8i5.1667",
+            "ISSN": "2384-9428",
+            "shortTitle": "",
+            "url": "https://mediageo.it/ojs/index.php/archeomatica/article/view/1667",
+            "accessDate": "2021-08-11T15:06:50Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "mediageo.it",
+            "callNumber": "",
+            "rights": "Copyright (c) 2019 Archeomatica",
+            "extra": "Number: 5",
+            "tags": [
+                {
+                    "tag": "⚠️ Invalid DOI",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/IG5FSTMD",
+                    "http://zotero.org/groups/242005/items/VQDAMNGH"
+                ]
+            },
+            "dateAdded": "2021-08-11T15:06:50Z",
+            "dateModified": "2021-12-11T11:49:57Z"
+        }
+    },
+    {
+        "key": "ETX9Q8VE",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/ETX9Q8VE",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/ETX9Q8VE",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Schwartz et al.",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Schwartz, Daniel, et al. &#x201C;Modeling a Born-Digital Factoid Prosopography Using the TEI and Linked Data.&#x201D; <i>Journal of the Text Encoding Initiative</i>, forthcoming, https://hdl.handle.net/1969.1/192423.</div>\n</div>",
+        "citation": "<span>(Schwartz et al.)</span>",
+        "data": {
+            "key": "ETX9Q8VE",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "Modeling a Born-Digital Factoid Prosopography using the TEI and Linked Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Daniel",
+                    "lastName": "Schwartz"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Nathan",
+                    "lastName": "Gibson"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Katayoun",
+                    "lastName": "Torabi"
+                }
+            ],
+            "abstractNote": "Although the TEI has traditionally been used for encoding text, its combination of structured and semi-structured data has made it a compelling choice for born-digital, linked-data resources as well. Our intent here is to demonstrate the advantages it offers for digital prosopographies along with a model that can be used for them. Syriac Persons, Events, and Relations (SPEAR) is a born digital prosopography project in the field of Syriac studies. Where traditional prosopographies focused on prose descriptions of individual persons of significance, SPEAR follows recent developments in research methodologies that instead produce prosopographical factoids. Factoids are structured data about persons drawn from the analysis of historical texts. Most factoid prosopographies use relational databases to model data. Instead, SPEAR uses a customized TEI schema to model factoids that can be queried and visualized in an XML database as well as serialized in HTML for human viewers and in RDF for data sharing. The TEI’s provisions for structured and semi-structured data make it ideal for encoding data from heterogeneous historical source material. Moreover, its linking capabilities connect SPEAR data to related data sets. By modeling prosopographical factoids, and not the source texts themselves, SPEAR offers an example of how a born-digital, data-oriented approach to using the TEI can circumvent some of the challenges posed by the tree structure of XML. It also disrupts traditional understandings of data and stand-off markup through combining Linked Open Data approaches with the use of the TEI.",
+            "publicationTitle": "Journal of the Text Encoding Initiative",
+            "volume": "",
+            "issue": "",
+            "pages": "",
+            "date": "forthcoming",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://hdl.handle.net/1969.1/192423",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VUNJPPMK"
+            },
+            "dateAdded": "2021-07-06T20:01:56Z",
+            "dateModified": "2021-12-11T11:49:57Z"
+        }
+    },
+    {
+        "key": "XXG3TBBQ",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/XXG3TBBQ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/XXG3TBBQ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Nurmikko-Fuller and Pickering",
+            "parsedDate": "2021-08-30",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Nurmikko-Fuller, Terhi, and Paul Pickering. &#x201C;Reductio Ad Absurdum?: From Analogue Hypertext to Digital Humanities.&#x201D; <i>Proceedings of the 32nd ACM Conference on Hypertext and Social Media</i>, Association for Computing Machinery, 2021, pp. 245&#x2013;250, https://doi.org/10/gncj96.</div>\n</div>",
+        "citation": "<span>(Nurmikko-Fuller and Pickering)</span>",
+        "data": {
+            "key": "XXG3TBBQ",
+            "version": 530,
+            "itemType": "conferencePaper",
+            "title": "Reductio ad absurdum?: From Analogue Hypertext to Digital Humanities",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Terhi",
+                    "lastName": "Nurmikko-Fuller"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Pickering"
+                }
+            ],
+            "abstractNote": "In this paper we report on a complex and complete archive of historical primary sources that map the political landscape of the anglophone world in the mid-to late 1800s. The ruthless pragmatism applied to the construction of the initial Humanities dataset resulted in an analogue equivalent of a hypertext system, which has already resulted in published academic books and articles. Here, we describe the processes of a current project, which consists of the translation of this analogue information aggregation system into a graph database using Linked Data and semantic Web technologies.",
+            "date": "August 30, 2021",
+            "proceedingsTitle": "Proceedings of the 32nd ACM Conference on Hypertext and Social Media",
+            "conferenceName": "",
+            "place": "New York, NY, USA",
+            "publisher": "Association for Computing Machinery",
+            "volume": "",
+            "pages": "245–250",
+            "series": "HT '21",
+            "language": "",
+            "DOI": "10/gncj96",
+            "ISBN": "978-1-4503-8551-0",
+            "shortTitle": "Reductio ad absurdum?",
+            "url": "https://doi.org/10.1145/3465336.3475107",
+            "accessDate": "2021-08-31",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "ACM Digital Library",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/HMZ4FRKN"
+            },
+            "dateAdded": "2021-08-31T17:06:24Z",
+            "dateModified": "2021-12-11T11:49:56Z"
+        }
+    },
+    {
+        "key": "IBE4TZCN",
+        "version": 529,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IBE4TZCN",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IBE4TZCN",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Golden and Shaw",
+            "parsedDate": "2015-05-18",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Golden, Patrick, and Ryan Shaw. &#x201C;Period Assertion as Nanopublication: The PeriodO Period Gazetteer.&#x201D; <i>Proceedings of the 24th International Conference on World Wide Web</i>, Association for Computing Machinery, 2015, pp. 1013&#x2013;1018, https://doi.org/10/gnrdmj.</div>\n</div>",
+        "citation": "<span>(Golden and Shaw)</span>",
+        "data": {
+            "key": "IBE4TZCN",
+            "version": 529,
+            "itemType": "conferencePaper",
+            "title": "Period Assertion as Nanopublication: The PeriodO Period Gazetteer",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Patrick",
+                    "lastName": "Golden"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ryan",
+                    "lastName": "Shaw"
+                }
+            ],
+            "abstractNote": "The PeriodO period gazetteer collects definitions of time periods made by archaeologists and other historical scholars. In constructing the gazetteer, we sought to make period definitions parsable and comparable by computers while also retaining the broader scholarly context in which they were conceived. Our approach resulted in a dataset of period definitions and their provenances that resemble what data scientists working in the e-science domain have dubbed \"nanopublications.\" In this paper we describe the origin and goals of nanopublications, provide an overview of the design and implementation of a database of period definitions, and highlight the similarities and differences between the two.",
+            "date": "May 18, 2015",
+            "proceedingsTitle": "Proceedings of the 24th International Conference on World Wide Web",
+            "conferenceName": "",
+            "place": "New York, NY, USA",
+            "publisher": "Association for Computing Machinery",
+            "volume": "",
+            "pages": "1013–1018",
+            "series": "WWW '15 Companion",
+            "language": "",
+            "DOI": "10/gnrdmj",
+            "ISBN": "978-1-4503-3473-0",
+            "shortTitle": "Period Assertion as Nanopublication",
+            "url": "https://doi.org/10.1145/2740908.2742021",
+            "accessDate": "2021-10-16",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "ACM Digital Library",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/T79TMG8G"
+            },
+            "dateAdded": "2021-10-16T15:21:01Z",
+            "dateModified": "2021-12-11T11:49:56Z"
+        }
+    },
+    {
+        "key": "VLPF5IIM",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VLPF5IIM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VLPF5IIM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Frank et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Frank, Emily, et al., editors. &#x201C;Integration of Photogrammetry, Reflectance Transformation Imaging (RTI), and Multiband Imaging (MBI) for Visualization, Documentation, and Analysis of Archaeological and Related Materials.&#x201D; <i>ISAW Papers</i>, vol. 21, 2021, http://hdl.handle.net/2333.1/0cfxq0c3.</div>\n</div>",
+        "citation": "<span>(Frank et al.)</span>",
+        "data": {
+            "key": "VLPF5IIM",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "Integration of Photogrammetry, Reflectance Transformation Imaging (RTI), and Multiband Imaging (MBI) for Visualization, Documentation, and Analysis of Archaeological and Related Materials",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Emily",
+                    "lastName": "Frank"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Chantal",
+                    "lastName": "Stein"
+                }
+            ],
+            "abstractNote": "This paper describes a practical workflow that enables the integration of Photogrammetry-based 3D modeling, Reflectance Transformation Imaging (RTI), and Multiband Imaging (MBI) into a single representation that can, in turn, be rendered visually using existing open-source software. To illustrate the workflow, we apply it to a fragment of an Egyptian painted wood sarcophagus now in the Institute of Fine Arts Study (NYU) Collection and then show how the results can contribute to the visualization, documentation, and analysis of archaeological and related materials. One product of this work is an animation rendered using the open-source software Blender. The animation emphasizes aspects of surface variation and reveals the craftwork involved in producing the sarcophagus fragment. In doing so, it highlights that the workflow we describe can serve many purposes and contribute to a wide variety of research agendas.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "21",
+            "issue": "",
+            "pages": "",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/0cfxq0c3",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/4Y8GA6PB"
+            },
+            "dateAdded": "2021-06-21T18:28:20Z",
+            "dateModified": "2021-12-11T11:49:55Z"
+        }
+    },
+    {
+        "key": "MPWP4NNS",
+        "version": 529,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/MPWP4NNS",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/MPWP4NNS",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Grigoraș and Panaite",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Grigora&#x219;, Bianca, and Adriana Panaite. &#x201C;The Late Roman Amphorae from Tropaeum Traiani, Sector A (North of the Basilica A), 2005&#x2013;2016.&#x201D; <i>Materiale &#x15E;i Cercet&#x103;ri Arheologice</i>, vol. 17, no. 1, 2021, pp. 87&#x2013;114, https://doi.org/10/gnrdmh.</div>\n</div>",
+        "citation": "<span>(Grigoraș and Panaite)</span>",
+        "data": {
+            "key": "MPWP4NNS",
+            "version": 529,
+            "itemType": "journalArticle",
+            "title": "The Late Roman Amphorae from Tropaeum Traiani, Sector A (north of the Basilica A), 2005–2016",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Bianca",
+                    "lastName": "Grigoraș"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Adriana",
+                    "lastName": "Panaite"
+                }
+            ],
+            "abstractNote": "This paper reports the characterization of 82 amphorae fragments discovered in archaeological contexts at Tropaeum Traiani (Adamclisi, Constanţa County, Romania), in Sector A (north of the Basilica A), from 2005 to 2016, dated between the 4th– 6th centuries AD, in an attempt to understand the consumption and circulation of different commodities, as well as the trade connections of this settlement from the Lower Danube with the rest of the Roman world during the Late Antiquity period. The 82 fragments of Late Roman amphorae presented in this study belong to an assemblage including a total number of 283 amphorae fragments. The ceramic material is divided into 15 types, subtypes and variants of amphorae. The statistics based on the entire amphorae assemblage show the predominance of LRA 2 (38%) and LRA 1 (33%), while LRA 3 is less represented. The imports of olive oil represent 76% of the total imports, while wine only 24%.",
+            "publicationTitle": "Materiale şi cercetări arheologice",
+            "volume": "17",
+            "issue": "1",
+            "pages": "87-114",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "eng",
+            "DOI": "10/gnrdmh",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "https://www.persee.fr/doc/mcarh_1220-5222_2021_num_17_1_2152",
+            "accessDate": "2021-10-27T21:46:42Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "personal",
+            "callNumber": "Late Roman Amphorae from Tropaeum Traiani.pdf",
+            "rights": "free",
+            "extra": "Publisher: Persée - Portail des revues scientifiques en SHS",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-10-27T21:49:50Z",
+            "dateModified": "2021-12-11T11:49:55Z"
+        }
+    },
+    {
+        "key": "UERQTL9D",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/UERQTL9D",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/UERQTL9D",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Liuzzo",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Liuzzo, Pietro. &#x201C;Serving IIIF and DTS APIs Specifications from TEI Data via XQuery with Support from a SPARQL Endpoint.&#x201D; <i>Proceedings of Balisage: The Markup Conference 2021</i>, vol. 26, 2021, https://doi.org/10/gnrdmm.</div>\n</div>",
+        "citation": "<span>(Liuzzo)</span>",
+        "data": {
+            "key": "UERQTL9D",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "Serving IIIF and DTS APIs specifications from TEI data via XQuery with support from a SPARQL Endpoint",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Pietro",
+                    "lastName": "Liuzzo"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Proceedings of Balisage: The Markup Conference 2021",
+            "volume": "26",
+            "issue": "",
+            "pages": "",
+            "date": "2021",
+            "series": "Balisage Series on Markup Technologies",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gnrdmm",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/XY8KJR9N"
+            },
+            "dateAdded": "2021-08-09T12:46:44Z",
+            "dateModified": "2021-12-11T11:49:54Z"
+        }
+    },
+    {
+        "key": "X9FH2FWM",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/X9FH2FWM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/X9FH2FWM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Komar",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Komar, Paulina. &#x201C;Aegean Enigma: The Rise and Fall of Vineyards during Antiquity.&#x201D; <i>ELECTRUM</i>, no. Volume 27, 2020, pp. 33&#x2013;43, https://doi.org/10/gnrdmn. World.</div>\n</div>",
+        "citation": "<span>(Komar)</span>",
+        "data": {
+            "key": "X9FH2FWM",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "Aegean Enigma: The Rise and Fall of Vineyards during Antiquity",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Paulina",
+                    "lastName": "Komar"
+                }
+            ],
+            "abstractNote": "Aegean Enigma: The Rise and Fall of Vineyards during Antiquity",
+            "publicationTitle": "ELECTRUM",
+            "volume": "",
+            "issue": "Volume 27",
+            "pages": "33-43",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmn",
+            "ISSN": "2084-3909",
+            "shortTitle": "Aegean Enigma",
+            "url": "https://www.ejournals.eu/electrum/2020/Volume-27/art/17769/",
+            "accessDate": "2021-07-07T14:43:53Z",
+            "archive": "",
+            "archiveLocation": "World",
+            "libraryCatalog": "www.ejournals.eu",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Number: Volume 27\nPublisher: Portal Czasopism Naukowych Ejournals.eu",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-07-07T14:43:53Z",
+            "dateModified": "2021-12-11T11:49:54Z"
+        }
+    },
+    {
+        "key": "IQUBRQG4",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IQUBRQG4",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IQUBRQG4",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Collins-Elliott",
+            "parsedDate": "2018",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Collins-Elliott, Stephen. &#x201C;A Behavioral Analysis of Monetary Exchange and Craft Production in Rural Tuscany via Small Finds from the Roman Peasant Project | Collins-Elliott |.&#x201D; <i>Journal of Mediterranean Archaeology</i>, vol. 31, no. 2, 2018, pp. 155&#x2013;79, https://doi.org/10/gf5zf3.</div>\n</div>",
+        "citation": "<span>(Collins-Elliott)</span>",
+        "data": {
+            "key": "IQUBRQG4",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "A Behavioral Analysis of Monetary Exchange and Craft Production in Rural Tuscany via Small Finds from the Roman Peasant Project | Collins-Elliott |",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Stephen",
+                    "lastName": "Collins-Elliott"
+                }
+            ],
+            "abstractNote": "Roman archaeology has long made use of an urban-rural dichotomy to conceptualize and frame questions about the material record, carrying over values of urbanism and rusticity explicit in ancient textual sources. The construction of rural culture deserves articulation not as a received idea, but through comparison of actual assemblages recovered from archaeological contexts in the countryside. Accordingly, this paper uses the small finds from the Roman Peasant Project (2009-2014), a project to study the lives of the ancient inhabitants of the comune of Cinigiano (GR), to investigate behavioral patterns at seven sites in south-central Tuscany. I utilize a computational approach which automates the process of interpreting finds as indices of different behaviors and I compare the socioeconomic landscape of this rural community in two broad periods, the late Republican / Julio-Claudian and Late Antique. I show not only that a formal, quantitative approach to the categorization of finds and comparison of site functionality can be used to measure overall variability in each period, but also that it is possible to assess the behavioral factors that lay behind the makeup of the Roman rural economy in this region. In the earlier period, peasants' lives were distinguished by lower levels of coin circulation and greater variability in site investment, although with a more homogenous lifestyle. In Late Antiquity, craft production and coin-based exchange were much more diffuse throughout society, perhaps indicating diminishing networks of long-term reciprocity and interdependency among different communities as local production and cash transactions became more common.",
+            "publicationTitle": "Journal of Mediterranean Archaeology",
+            "volume": "31",
+            "issue": "2",
+            "pages": "155-179",
+            "date": "2018",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "10/gf5zf3",
+            "ISSN": "1743-1700",
+            "shortTitle": "",
+            "url": "https://journals.equinoxpub.com/JMA/article/view/38081",
+            "accessDate": "2021-07-14T18:20:19Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/4R5XBQPH"
+            },
+            "dateAdded": "2021-07-14T18:20:19Z",
+            "dateModified": "2021-12-11T11:49:53Z"
+        }
+    },
+    {
+        "key": "4R5XBQPH",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/4R5XBQPH",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/4R5XBQPH",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Hoyer",
+            "parsedDate": "2018",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Hoyer, Daniel. &#x201C;An Overview of the Numismatic Evidence from Imperial Roman Africa.&#x201D; <i>ISAW Papers</i>, vol. 13, 2018, http://hdl.handle.net/2333.1/76hdrfz3.</div>\n</div>",
+        "citation": "<span>(Hoyer)</span>",
+        "data": {
+            "key": "4R5XBQPH",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "An Overview of the Numismatic Evidence from Imperial Roman Africa",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Daniel",
+                    "lastName": "Hoyer"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "13",
+            "issue": "",
+            "pages": "",
+            "date": "2018",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/76hdrfz3",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/IQUBRQG4"
+            },
+            "dateAdded": "2021-04-06T17:37:01Z",
+            "dateModified": "2021-12-11T11:49:53Z"
+        }
+    },
+    {
+        "key": "WMCJZXB9",
+        "version": 530,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WMCJZXB9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WMCJZXB9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Cloke and Athanassopoulos",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Cloke, Christian, and Effie Athanassopoulos. &#x201C;Late Antique and Medieval Landscapes of the Nemea Valley, Southern Greece.&#x201D; <i>Journal of Greek Archaeology</i>, vol. 5, 2020, pp. 406&#x2013;425&#x2013;406&#x2013;425, https://doi.org/10/gnrdmp.</div>\n</div>",
+        "citation": "<span>(Cloke and Athanassopoulos)</span>",
+        "data": {
+            "key": "WMCJZXB9",
+            "version": 530,
+            "itemType": "journalArticle",
+            "title": "Late Antique and Medieval Landscapes of the Nemea Valley, Southern Greece",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christian",
+                    "lastName": "Cloke"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Effie",
+                    "lastName": "Athanassopoulos"
+                }
+            ],
+            "abstractNote": "In the last 40 years regional survey projects and excavations in the Aegean region have produced a rich record of Late Antique and Medieval land use and settlement. They have provided information about rural sites and villages, subjects that are poorly covered by historical sources. In this paper we examine the contribution of surface survey, along with information derived from excavation, to the understanding of these periods. The case study comes from the region of Nemea, in southern Greece, which has been the focus of excavations by the University of California-Berkeley and an intensive survey as part of the Nemea Valley Archaeological Project (NVAP) (Figure 1a-b).",
+            "publicationTitle": "Journal of Greek Archaeology",
+            "volume": "5",
+            "issue": "",
+            "pages": "406–425-406–425",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gnrdmp",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://archaeopresspublishing.com/ojs/index.php/JGA/article/view/442",
+            "accessDate": "2021-09-21T11:53:12Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "archaeopresspublishing.com",
+            "callNumber": "",
+            "rights": "Copyright (c) 2021 Journal of Greek Archaeology",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/5M493H7W"
+            },
+            "dateAdded": "2021-09-21T11:56:33Z",
+            "dateModified": "2021-12-11T11:49:52Z"
+        }
+    },
+    {
+        "key": "4Y8GA6PB",
+        "version": 529,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/4Y8GA6PB",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/4Y8GA6PB",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Radpour et al.",
+            "parsedDate": "2021-10-16",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Radpour, Roxanne, et al. &#x201C;A 3D Modeling Workflow to Map Ultraviolet- and Visible-Induced Luminescent Materials on Ancient Polychrome Artifacts.&#x201D; <i>Digital Applications in Archaeology and Cultural Heritage</i>, Oct. 2021, p. e00205, https://doi.org/10/gnrdmg.</div>\n</div>",
+        "citation": "<span>(Radpour et al.)</span>",
+        "data": {
+            "key": "4Y8GA6PB",
+            "version": 529,
+            "itemType": "journalArticle",
+            "title": "A 3D modeling workflow to map ultraviolet- and visible-induced luminescent materials on ancient polychrome artifacts",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Roxanne",
+                    "lastName": "Radpour"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christian",
+                    "lastName": "Fischer"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ioanna",
+                    "lastName": "Kakoulli"
+                }
+            ],
+            "abstractNote": "A 2D visualization approach for ensembles of images comprising RGB and luminescence photographs is traditionally used for studying the structure and chemistry of 3D polychrome ancient objects. Here, a method is presented for visualizing material composition of an object in 3D, providing artistic production information, conservation history, and virtual enhancement of faded, concealed and weathered decoration. The approach is based on the fusion of 2D luminescence forensic photographs with RGB images acquired using principles of structure-from-motion photogrammetry to build 3D models. Its potential is demonstrated in a study of a polychrome Hellenistic terracotta funerary head vase, in which three models of the vase were produced: (1) photorealistic; (2) visible-induced luminescence, mapping Egyptian blue and madder lake; and (3) ultraviolet-induced visible luminescence, revealing surface condition and previous conservation interventions. The workflow advances current approaches in modeling chemical signatures of luminescent pigments, extending their traditional 2D viewing platform into 3D.",
+            "publicationTitle": "Digital Applications in Archaeology and Cultural Heritage",
+            "volume": "",
+            "issue": "",
+            "pages": "e00205",
+            "date": "October 16, 2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "Digital Applications in Archaeology and Cultural Heritage",
+            "language": "en",
+            "DOI": "10/gnrdmg",
+            "ISSN": "2212-0548",
+            "shortTitle": "",
+            "url": "https://www.sciencedirect.com/science/article/pii/S2212054821000345",
+            "accessDate": "2021-10-19T21:33:57Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "ScienceDirect",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VLPF5IIM"
+            },
+            "dateAdded": "2021-10-19T21:34:26Z",
+            "dateModified": "2021-12-11T11:49:52Z"
+        }
+    },
+    {
+        "key": "JIL6WQ3H",
+        "version": 529,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/JIL6WQ3H",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/JIL6WQ3H",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Köntges et al.",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">K&#xF6;ntges, Thomas, et al. <i>Open Greek and Latin: Digital Humanities in an Open Collaboration with Pedagogy</i>. 2017, http://library.ifla.org/id/eprint/2551/.</div>\n</div>",
+        "citation": "<span>(Köntges et al.)</span>",
+        "data": {
+            "key": "JIL6WQ3H",
+            "version": 529,
+            "itemType": "conferencePaper",
+            "title": "Open Greek and Latin: Digital Humanities in an Open Collaboration with Pedagogy",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Thomas",
+                    "lastName": "Köntges"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Rhea",
+                    "lastName": "Lesage"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Bruce",
+                    "lastName": "Robertson"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Jeannie",
+                    "lastName": "Sellick"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Lucie Wall",
+                    "lastName": "Stylianopoulos"
+                }
+            ],
+            "abstractNote": "This paper outlines and describes the work flow used to create the First Thousand Years of Greek component of the Open Greek and Latin project. Open Greek and Latin (OGL) is an international collaborative consortium of librarians, faculty and researchers committed to creating an Open Educational Resource (OER) featuring a corpus of digital texts, deep-reading tools, and open-source software. The consortium is working to free researchers (and library resources) from dependence on commercialized data and addresses the growing need for open textual corpora to support new forms of born-digital annotation, advanced reading practices, and expanded audiences for pre-modern Greek and Latin. The authors include two use cases for the open access collection and suggest expanded research opportunities as it grows to include multilingual translations and editions. They describe the challenges and opportunities encountered in the process and propose ways in which this international collaboration can grow via distributed teams of librarians, faculty, students, and researchers.",
+            "date": "2017",
+            "proceedingsTitle": "",
+            "conferenceName": "",
+            "place": "",
+            "publisher": "",
+            "volume": "",
+            "pages": "",
+            "series": "",
+            "language": "en",
+            "DOI": "",
+            "ISBN": "",
+            "shortTitle": "Open Greek and Latin",
+            "url": "http://library.ifla.org/id/eprint/2551/",
+            "accessDate": "2021-11-22T15:15:05Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "library.ifla.org",
+            "callNumber": "",
+            "rights": "cc_by_4",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/C97R9EGF"
+            },
+            "dateAdded": "2021-11-22T15:15:05Z",
+            "dateModified": "2021-12-11T11:49:51Z"
+        }
+    },
+    {
+        "key": "8DAPBQM3",
+        "version": 608,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8DAPBQM3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8DAPBQM3",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bond et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bond, Sarah, et al., editors. &#x201C;Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects.&#x201D; <i>ISAW Papers</i>, vol. 20, 2021, http://hdl.handle.net/2333.1/gqnk9kz2.</div>\n</div>",
+        "citation": "<span>(Bond et al.)</span>",
+        "data": {
+            "key": "8DAPBQM3",
+            "version": 608,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sarah",
+                    "lastName": "Bond"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "20",
+            "issue": "",
+            "pages": "",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/gqnk9kz2",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/69Y3ERPQ"
+            },
+            "dateAdded": "2021-04-06T17:26:44Z",
+            "dateModified": "2021-12-11T11:49:49Z"
+        }
+    },
+    {
+        "key": "F6BFDH87",
+        "version": 592,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/F6BFDH87",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/F6BFDH87",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Jones",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Jones, Alexander. &#x201C;The Epoch Dates of the Antikythera Mechanism (With an Appendix on Its Authenticity).&#x201D; <i>ISAW Papers</i>, vol. 17, 2020, http://hdl.handle.net/2333.1/ffbg7m07.</div>\n</div>",
+        "citation": "<span>(Jones)</span>",
+        "data": {
+            "key": "F6BFDH87",
+            "version": 592,
+            "itemType": "journalArticle",
+            "title": "The Epoch Dates of the Antikythera Mechanism (With an Appendix on its Authenticity)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "17",
+            "issue": "",
+            "pages": "",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/ffbg7m07",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/8UAXIJEL"
+            },
+            "dateAdded": "2021-04-06T17:32:01Z",
+            "dateModified": "2021-12-11T11:49:49Z"
+        }
+    },
+    {
+        "key": "VQDAMNGH",
+        "version": 538,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VQDAMNGH",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VQDAMNGH",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Freeth and Jones",
+            "parsedDate": "2012",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Freeth, Tony, and Alexander Jones. &#x201C;The Cosmos in the Antikythera Mechanism.&#x201D; <i>ISAW Papers</i>, vol. 4, 2012, http://dlib.nyu.edu/awdl/isaw/isaw-papers/4/.</div>\n</div>",
+        "citation": "<span>(Freeth and Jones)</span>",
+        "data": {
+            "key": "VQDAMNGH",
+            "version": 538,
+            "itemType": "journalArticle",
+            "title": "The Cosmos in the Antikythera Mechanism",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Tony",
+                    "lastName": "Freeth"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                }
+            ],
+            "abstractNote": "The Antikythera Mechanism is a fragmentarily preserved Hellenistic astronomical machine with bronze gearwheels, made about the second century B.C. In 2005, new data were gathered leading to considerably enhanced knowledge of its functions and the inscriptions on its exterior. However, much of the front of the instrument has remained uncertain due to loss of evidence. We report progress in reading a passage of one inscription that appears to describe the front of the Mechanism as a representation of a Greek geocentric cosmology, portraying the stars, Sun, Moon, and all five planets known in antiquity. Complementing this, we propose a new mechanical reconstruction of planetary gearwork in the Mechanism, incorporating an economical design closely analogous to the previously identified lunar anomaly mechanism, and accounting for much unresolved physical evidence.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "4",
+            "issue": "",
+            "pages": "",
+            "date": "2012",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/4/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/KUYAWYLM",
+                    "http://zotero.org/groups/242005/items/ZUET4RGW",
+                    "http://zotero.org/groups/242005/items/THVV3TGW",
+                    "http://zotero.org/groups/242005/items/6EJ525KM",
+                    "http://zotero.org/groups/242005/items/S6ZQGI6J",
+                    "http://zotero.org/groups/242005/items/LIM5E67E",
+                    "http://zotero.org/groups/242005/items/YCVAYAR6",
+                    "http://zotero.org/groups/242005/items/BX475BJC",
+                    "http://zotero.org/groups/242005/items/R38RHVA2"
+                ]
+            },
+            "dateAdded": "2014-01-15T15:21:48Z",
+            "dateModified": "2021-12-11T11:49:48Z"
+        }
+    },
+    {
+        "key": "NESJQCMQ",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/NESJQCMQ",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/NESJQCMQ",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Carman and Duke",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Carman, Christi&#xE1;n C., and Dennis Duke. &#x201C;Tables of Synodic Events from -800 to 1650 Using Modern and Almagest Models.&#x201D; <i>ISAW Papers</i>, vol. 15, 2019, http://hdl.handle.net/2333.1/2fqz68dk.</div>\n</div>",
+        "citation": "<span>(Carman and Duke)</span>",
+        "data": {
+            "key": "NESJQCMQ",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "Tables of Synodic Events from -800 to 1650 Using Modern and Almagest Models",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Christián C.",
+                    "lastName": "Carman"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Dennis",
+                    "lastName": "Duke"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "15",
+            "issue": "",
+            "pages": "",
+            "date": "2019",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/2fqz68dk",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-06T17:34:36Z",
+            "dateModified": "2021-12-11T11:49:48Z"
+        }
+    },
+    {
+        "key": "5M493H7W",
+        "version": 594,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5M493H7W",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5M493H7W",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Heath et al.",
+            "parsedDate": "2015",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Heath, Sebastian, et al. &#x201C;Preliminary Report on Early Byzantine Pottery from a Building Complex at Kenchreai (Greece).&#x201D; <i>ISAW Papers</i>, vol. 10, 2015, http://dlib.nyu.edu/awdl/isaw/isaw-papers/10/.</div>\n</div>",
+        "citation": "<span>(Heath et al.)</span>",
+        "data": {
+            "key": "5M493H7W",
+            "version": 594,
+            "itemType": "journalArticle",
+            "title": "Preliminary Report on Early Byzantine Pottery from a Building Complex at Kenchreai (Greece)",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Joseph L.",
+                    "lastName": "Rife"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Jorge J.",
+                    "lastName": "Bravo III"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Gavin",
+                    "lastName": "Blasdel"
+                }
+            ],
+            "abstractNote": "This paper presents the results of preliminary study of Early Byzantine pottery from a large building near the waterfront at Kenchreai in southern Greece. Kenchreai served as the eastern port of Corinth throughout antiquity. The building was first excavated in 1976 by the Greek Archaeological Service, and it has been investigated since 2014 by the American Excavations at Kenchreai with permission from the Ministry of Culture under the auspices of the American School of Classical Studies at Athens. The pottery is characterized by the presence of many Late Roman Amphora 2 rims as well as stoppers and funnels. This indicates that the building had a role in the distribution of regional agricultural products during its final phase, which is dated to the very late sixth or early seventh centures A.D. by African Red-Slip and Phocaean Red-Slip tablewares. A wide range of lamps, glass vessels, and other small finds has also been recorded. Results to date are preliminary but ongoing work may allow further precision as to the chronology and use of this building.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "10",
+            "issue": "",
+            "pages": "",
+            "date": "2015",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/10/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "CC-By",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/P3WI95NM",
+                    "http://zotero.org/groups/242005/items/5QRUQUXS",
+                    "http://zotero.org/groups/242005/items/KW7KGHQF",
+                    "http://zotero.org/groups/242005/items/5PKSQNFT",
+                    "http://zotero.org/groups/242005/items/WMCJZXB9",
+                    "http://zotero.org/groups/242005/items/MPWP4NNS",
+                    "http://zotero.org/groups/242005/items/GD58GU7B",
+                    "http://zotero.org/groups/242005/items/8F34F8P7"
+                ]
+            },
+            "dateAdded": "2015-09-11T16:06:37Z",
+            "dateModified": "2021-12-11T11:49:47Z"
+        }
+    },
+    {
+        "key": "P3Y9LBC4",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/P3Y9LBC4",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/P3Y9LBC4",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bond et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bond, Sarah E., et al. &#x201C;Introducing the Semantic Web and Linked Open Data.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 1, 2021, http://hdl.handle.net/2333.1/c2fqzh3d.</div>\n</div>",
+        "citation": "<span>(Bond et al.)</span>",
+        "data": {
+            "key": "P3Y9LBC4",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "Introducing the Semantic Web and Linked Open Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sarah E.",
+                    "lastName": "Bond"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "1",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/c2fqzh3d",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T13:57:31Z",
+            "dateModified": "2021-12-11T11:49:47Z"
+        }
+    },
+    {
+        "key": "5A46BUSX",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/5A46BUSX",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/5A46BUSX",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Greenbaum and Jones",
+            "parsedDate": "2017",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Greenbaum, Dorian G., and Alexander Jones. &#x201C;P.Berl. 9825: An Elaborate Horoscope for 319 CE and Its Significance for Greek Astronomical and Astrological Practice.&#x201D; <i>ISAW Papers</i>, vol. 12, 2017, http://hdl.handle.net/2333.1/brv15m2n.</div>\n</div>",
+        "citation": "<span>(Greenbaum and Jones)</span>",
+        "data": {
+            "key": "5A46BUSX",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "P.Berl. 9825: An elaborate horoscope for 319 CE and its significance for Greek astronomical and astrological practice.",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Dorian G.",
+                    "lastName": "Greenbaum"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "12",
+            "issue": "",
+            "pages": "",
+            "date": "2017",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/brv15m2n",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/WVB5DW37",
+                    "http://zotero.org/groups/242005/items/RVL2PN5W",
+                    "http://zotero.org/groups/242005/items/I92UGNRJ"
+                ]
+            },
+            "dateAdded": "2021-04-06T17:37:51Z",
+            "dateModified": "2021-12-11T11:49:46Z"
+        }
+    },
+    {
+        "key": "XY8KJR9N",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/XY8KJR9N",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/XY8KJR9N",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bodard",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bodard, Gabriel. &#x201C;Linked Open Data for Ancient Names and People.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 4, 2021, http://hdl.handle.net/2333.1/zs7h4fs8.</div>\n</div>",
+        "citation": "<span>(Bodard)</span>",
+        "data": {
+            "key": "XY8KJR9N",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for Ancient Names and People",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Gabriel",
+                    "lastName": "Bodard"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "4",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/zs7h4fs8",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/UERQTL9D"
+            },
+            "dateAdded": "2021-04-15T14:45:03Z",
+            "dateModified": "2021-12-11T11:49:46Z"
+        }
+    },
+    {
+        "key": "VTNEJVFG",
+        "version": 573,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VTNEJVFG",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VTNEJVFG",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bransbourg",
+            "parsedDate": "2012",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bransbourg, Gilles. &#x201C;Rome and the Economic Integration of Empire.&#x201D; <i>ISAW Papers</i>, vol. 3, 2012, http://dlib.nyu.edu/awdl/isaw/isaw-papers/3/.</div>\n</div>",
+        "citation": "<span>(Bransbourg)</span>",
+        "data": {
+            "key": "VTNEJVFG",
+            "version": 573,
+            "itemType": "journalArticle",
+            "title": "Rome and the Economic Integration of Empire",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Gilles",
+                    "lastName": "Bransbourg"
+                }
+            ],
+            "abstractNote": "The modern economist Peter Temin has recently used econometrics to argue that the Roman grain market was an integrated and efficient market. This paper gathers additional data and applies further methods of modern economic analysis to reach a different conclusion. It shows that the overall Roman economy was not fully integrated, although the Mediterranean Sea did create some meaningful integration along a few privileged trade routes. Still, it is not possible to identify pure market forces that existed in isolation, since the political structures that maintained the Empire strongly influenced the movement of money and trade goods.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "3",
+            "issue": "",
+            "pages": "",
+            "date": "2012",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/3/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/CA8B3RC3",
+                    "http://zotero.org/groups/242005/items/IUM6NZJ2",
+                    "http://zotero.org/groups/242005/items/8LYY5MCI",
+                    "http://zotero.org/groups/242005/items/UEF9LT9P",
+                    "http://zotero.org/groups/242005/items/P77YCCX5",
+                    "http://zotero.org/groups/242005/items/EFUYM4Q9",
+                    "http://zotero.org/groups/242005/items/VMKQ9NFK",
+                    "http://zotero.org/groups/242005/items/5XC5S76H",
+                    "http://zotero.org/groups/242005/items/J5IPIFXX",
+                    "http://zotero.org/groups/242005/items/X9FH2FWM",
+                    "http://zotero.org/groups/242005/items/269W5TLK",
+                    "http://zotero.org/groups/242005/items/QIGL2GSN",
+                    "http://zotero.org/groups/242005/items/IZ4V9FNB"
+                ]
+            },
+            "dateAdded": "2014-01-15T15:20:04Z",
+            "dateModified": "2021-12-11T11:49:45Z"
+        }
+    },
+    {
+        "key": "INRT7FVK",
+        "version": 571,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/INRT7FVK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/INRT7FVK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Jones and Steele",
+            "parsedDate": "2011",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Jones, Alexander, and John Steele. &#x201C;A New Discovery of a Component of Greek Astrology in Babylonian Tablets: The &#x2018;Terms.&#x2019;&#x201D; <i>ISAW Papers</i>, vol. 1, 2011, http://dlib.nyu.edu/awdl/isaw/isaw-papers/1/.</div>\n</div>",
+        "citation": "<span>(Jones and Steele)</span>",
+        "data": {
+            "key": "INRT7FVK",
+            "version": 571,
+            "itemType": "journalArticle",
+            "title": "A New Discovery of a Component of Greek Astrology in Babylonian Tablets: The “Terms”",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Alexander",
+                    "lastName": "Jones"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "John",
+                    "lastName": "Steele"
+                }
+            ],
+            "abstractNote": "Two cuneiform astrological tablets in the British Museum provide the first evidence for Babylonian knowledge of the so-called \"doctrine of the Terms\" of Greco-Roman astrology (BM 36326 and BM 36628+36817+37197). Greek, Latin, and Egyptian astrological sources for the various systems of Terms and their origin are reviewed, followed by preliminary editions and translations of the relevant sections of the tablets. The system of Terms is shown to be so far the most technically complex component of Greek astrology to originate in Babylonia. Over the course of the Hellenistic period an Egyptian origin was ascribed to the systems of Terms as it was combined with components of Greek horoscopic astrology. By Ptolemy's day, this spurious history had largely displaced the true.",
+            "publicationTitle": "ISAW Papers",
+            "volume": "1",
+            "issue": "",
+            "pages": "",
+            "date": "2011",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "2164-1471",
+            "shortTitle": "",
+            "url": "http://dlib.nyu.edu/awdl/isaw/isaw-papers/1/",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": [
+                    "http://zotero.org/groups/242005/items/I92UGNRJ",
+                    "http://zotero.org/groups/242005/items/RQPL7P96",
+                    "http://zotero.org/groups/242005/items/L4CUMRHE",
+                    "http://zotero.org/groups/242005/items/CJX4VLZI",
+                    "http://zotero.org/groups/242005/items/M23ULELF",
+                    "http://zotero.org/groups/242005/items/KZTPXDV5"
+                ]
+            },
+            "dateAdded": "2014-01-15T15:10:56Z",
+            "dateModified": "2021-12-11T11:49:45Z"
+        }
+    },
+    {
+        "key": "446V7G9N",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/446V7G9N",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/446V7G9N",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Horne",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Horne, Ryan. &#x201C;Applying Linked Open Data Standards.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 2, 2021, http://hdl.handle.net/2333.1/79cnpgk2.</div>\n</div>",
+        "citation": "<span>(Horne)</span>",
+        "data": {
+            "key": "446V7G9N",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "Applying Linked Open Data Standards",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "2",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/79cnpgk2",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T14:29:09Z",
+            "dateModified": "2021-12-11T11:49:44Z"
+        }
+    },
+    {
+        "key": "CA8B3RC3",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/CA8B3RC3",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/CA8B3RC3",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Scheidel",
+            "parsedDate": "2014",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Scheidel, Walter. &#x201C;The Shape of the Roman World: Modelling Imperial Connectivity.&#x201D; <i>Journal of Roman Archaeology</i>, vol. 27, ed 2014, pp. 7&#x2013;32, https://doi.org/10/gd6csb.</div>\n</div>",
+        "citation": "<span>(Scheidel)</span>",
+        "data": {
+            "key": "CA8B3RC3",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "The shape of the Roman world: modelling imperial connectivity",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Walter",
+                    "lastName": "Scheidel"
+                }
+            ],
+            "abstractNote": "//static.cambridge.org/content/id/urn%3Acambridge.org%3Aid%3Aarticle%3AS1047759414001147/resource/name/firstPage-S1047759414001147a.jpg",
+            "publicationTitle": "Journal of Roman Archaeology",
+            "volume": "27",
+            "issue": "",
+            "pages": "7-32",
+            "date": "2014/ed",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "en",
+            "DOI": "10/gd6csb",
+            "ISSN": "1047-7594, 2331-5709",
+            "shortTitle": "The shape of the Roman world",
+            "url": "https://www.cambridge.org/core/journals/journal-of-roman-archaeology/article/abs/shape-of-the-roman-world-modelling-imperial-connectivity/E61006878912791FDEE7CFAD95530770",
+            "accessDate": "2021-04-13T02:26:19Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "Cambridge University Press",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Cambridge University Press",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-13T02:26:19Z",
+            "dateModified": "2021-12-11T11:49:44Z"
+        }
+    },
+    {
+        "key": "XI2FKWIC",
+        "version": 529,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/XI2FKWIC",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/XI2FKWIC",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Naether",
+            "parsedDate": "2020",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Naether, Franziska, editor. &#x201C;Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016.&#x201D; <i>ISAW Papers</i>, vol. 18, 2020, http://hdl.handle.net/2333.1/5dv41zmf.</div>\n</div>",
+        "citation": "<span>(Naether)</span>",
+        "data": {
+            "key": "XI2FKWIC",
+            "version": 529,
+            "itemType": "journalArticle",
+            "title": "Cult Practices in Ancient Literatures: Egyptian, Near Eastern and Graeco-Roman Narratives in a Cross-Cultural Perspective. Proceedings of a Workshop at the Institute for the Study of the Ancient World, New York, May 16-17, 2016",
+            "creators": [
+                {
+                    "creatorType": "editor",
+                    "firstName": "Franziska",
+                    "lastName": "Naether"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "18",
+            "issue": "",
+            "pages": "",
+            "date": "2020",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/5dv41zmf",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "8NU6UZ2D",
+                "7Z3766YC"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-06T17:30:24Z",
+            "dateModified": "2021-12-11T11:49:43Z"
+        }
+    },
+    {
+        "key": "IUM6NZJ2",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/IUM6NZJ2",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/IUM6NZJ2",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Arruñada",
+            "parsedDate": "2016-07-01",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Arru&#xF1;ada, Benito. &#x201C;How Rome Enabled Impersonal Markets.&#x201D; <i>Explorations in Economic History</i>, vol. 61, July 2016, pp. 68&#x2013;84, https://doi.org/10/gnrdmf.</div>\n</div>",
+        "citation": "<span>(Arruñada)</span>",
+        "data": {
+            "key": "IUM6NZJ2",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "How Rome enabled impersonal markets",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Benito",
+                    "lastName": "Arruñada"
+                }
+            ],
+            "abstractNote": "Impersonal exchange increases trade and specialization opportunities, encouraging economic growth. However, it requires the support of sophisticated public institutions. This paper explains how Classical Rome provided such support in the main areas of economic activity by relying on public possession as a titling device, enacting rules to protect innocent acquirers in agency contexts, enabling the extended family to act as a contractual entity, and diluting the enforcement of personal obligations which might collide with impersonal exchange. Focusing on the institutions of impersonal exchange, it reaches a clear positive conclusion on the market-facilitating role of the Roman state because such institutions have unambiguously positive effects on markets. Moreover, being impersonal, these beneficial effects are also widely distributed across society instead of accruing disproportionately to better-connected individuals.",
+            "publicationTitle": "Explorations in Economic History",
+            "volume": "61",
+            "issue": "",
+            "pages": "68-84",
+            "date": "July 1, 2016",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "Explorations in Economic History",
+            "language": "en",
+            "DOI": "10/gnrdmf",
+            "ISSN": "0014-4983",
+            "shortTitle": "",
+            "url": "https://www.sciencedirect.com/science/article/pii/S001449831600005X",
+            "accessDate": "2021-04-13T02:28:43Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "ScienceDirect",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "Enforcement",
+                    "type": 1
+                },
+                {
+                    "tag": "Impersonal exchange",
+                    "type": 1
+                },
+                {
+                    "tag": "Law and economics",
+                    "type": 1
+                },
+                {
+                    "tag": "New institutional economics",
+                    "type": 1
+                },
+                {
+                    "tag": "Personal exchange",
+                    "type": 1
+                },
+                {
+                    "tag": "Property rights",
+                    "type": 1
+                },
+                {
+                    "tag": "Roman law",
+                    "type": 1
+                },
+                {
+                    "tag": "Transaction costs",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-13T02:29:23Z",
+            "dateModified": "2021-12-11T11:49:43Z"
+        }
+    },
+    {
+        "key": "QG6RGDC9",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/QG6RGDC9",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/QG6RGDC9",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Bagnall and Bransbourg",
+            "parsedDate": "2019",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Bagnall, Roger S., and Gilles Bransbourg. &#x201C;The Constantian Monetary Revolution.&#x201D; <i>ISAW Papers</i>, vol. 14, 2019, http://hdl.handle.net/2333.1/3n5tb9sc.</div>\n</div>",
+        "citation": "<span>(Bagnall and Bransbourg)</span>",
+        "data": {
+            "key": "QG6RGDC9",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "The Constantian Monetary Revolution",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Roger S.",
+                    "lastName": "Bagnall"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Gilles",
+                    "lastName": "Bransbourg"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "ISAW Papers",
+            "volume": "14",
+            "issue": "",
+            "pages": "",
+            "date": "2019",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/3n5tb9sc",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "7Z3766YC"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/2BA25TAM"
+            },
+            "dateAdded": "2021-04-06T17:35:52Z",
+            "dateModified": "2021-12-11T11:49:43Z"
+        }
+    },
+    {
+        "key": "7527C82M",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/7527C82M",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/7527C82M",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Rabinowitz",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Rabinowitz, Adam. &#x201C;Time for Linked Open Data.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 3, 2021, http://hdl.handle.net/2333.1/3j9kdg35.</div>\n</div>",
+        "citation": "<span>(Rabinowitz)</span>",
+        "data": {
+            "key": "7527C82M",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Time for Linked Open Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Adam",
+                    "lastName": "Rabinowitz"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "3",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/3j9kdg35",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T14:39:40Z",
+            "dateModified": "2021-12-11T11:49:42Z"
+        }
+    },
+    {
+        "key": "8LYY5MCI",
+        "version": 528,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8LYY5MCI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8LYY5MCI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Dermody et al.",
+            "parsedDate": "2014-12-11",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Dermody, B. J., et al. &#x201C;A Virtual Water Network of the Roman World.&#x201D; <i>Hydrology and Earth System Sciences</i>, vol. 18, no. 12, Dec. 2014, pp. 5025&#x2013;40, https://doi.org/10/gb9nj9.</div>\n</div>",
+        "citation": "<span>(Dermody et al.)</span>",
+        "data": {
+            "key": "8LYY5MCI",
+            "version": 528,
+            "itemType": "journalArticle",
+            "title": "A virtual water network of the Roman world",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "B. J.",
+                    "lastName": "Dermody"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "R. P. H.",
+                    "lastName": "van Beek"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "E.",
+                    "lastName": "Meeks"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "K.",
+                    "lastName": "Klein Goldewijk"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "W.",
+                    "lastName": "Scheidel"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Y.",
+                    "lastName": "van der Velde"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "M. F. P.",
+                    "lastName": "Bierkens"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "M. J.",
+                    "lastName": "Wassen"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "S. C.",
+                    "lastName": "Dekker"
+                }
+            ],
+            "abstractNote": "<p><strong class=\"journal-contentHeaderColor\">Abstract.</strong> The Romans were perhaps the most impressive exponents of water resource management in preindustrial times with irrigation and virtual water trade facilitating unprecedented urbanization and socioeconomic stability for hundreds of years in a region of highly variable climate. To understand Roman water resource management in response to urbanization and climate variability, a Virtual Water Network of the Roman World was developed. Using this network we find that irrigation and virtual water trade increased Roman resilience to interannual climate variability. However, urbanization arising from virtual water trade likely pushed the Empire closer to the boundary of its water resources, led to an increase in import costs, and eroded its resilience to climate variability in the long term. In addition to improving our understanding of Roman water resource management, our cost–distance-based analysis illuminates how increases in import costs arising from climatic and population pressures are likely to be distributed in the future global virtual water network.</p>",
+            "publicationTitle": "Hydrology and Earth System Sciences",
+            "volume": "18",
+            "issue": "12",
+            "pages": "5025-5040",
+            "date": "2014/12/11",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "English",
+            "DOI": "10/gb9nj9",
+            "ISSN": "1027-5606",
+            "shortTitle": "",
+            "url": "https://hess.copernicus.org/articles/18/5025/2014/",
+            "accessDate": "2021-04-13T02:42:12Z",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "hess.copernicus.org",
+            "callNumber": "",
+            "rights": "",
+            "extra": "Publisher: Copernicus GmbH",
+            "tags": [],
+            "collections": [
+                "DZDZS5QD"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/VTNEJVFG"
+            },
+            "dateAdded": "2021-04-13T02:42:12Z",
+            "dateModified": "2021-12-11T11:49:41Z"
+        }
+    },
+    {
+        "key": "C97R9EGF",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/C97R9EGF",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/C97R9EGF",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Koentges et al.",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Koentges, Thomas, et al. &#x201C;The CITE Architecture: Q &amp; A Regarding CTS and CITE.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 8, 2021, http://hdl.handle.net/2333.1/fttdz9dt.</div>\n</div>",
+        "citation": "<span>(Koentges et al.)</span>",
+        "data": {
+            "key": "C97R9EGF",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "The CITE Architecture: Q & A Regarding CTS and CITE",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Thomas",
+                    "lastName": "Koentges"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Christopher",
+                    "lastName": "Blackwell"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Gregory",
+                    "lastName": "Crane"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Neel",
+                    "lastName": "Smith"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "James",
+                    "lastName": "Tauber"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "8",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/fttdz9dt",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/JIL6WQ3H"
+            },
+            "dateAdded": "2021-04-15T14:58:13Z",
+            "dateModified": "2021-12-11T11:49:39Z"
+        }
+    },
+    {
+        "key": "8WTAP7GI",
+        "version": 526,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/8WTAP7GI",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/8WTAP7GI",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Scates Kettler",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Scates Kettler, Hannah. &#x201C;Linked Open Data for 3D Models and Environments.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 5, 2021, http://hdl.handle.net/2333.1/v15dvf81.</div>\n</div>",
+        "citation": "<span>(Scates Kettler)</span>",
+        "data": {
+            "key": "8WTAP7GI",
+            "version": 526,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for 3D Models and Environments",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Hannah",
+                    "lastName": "Scates Kettler"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "5",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/v15dvf81",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:14:46Z",
+            "dateModified": "2021-12-11T11:49:39Z"
+        }
+    },
+    {
+        "key": "NCY9J3Z8",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/NCY9J3Z8",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/NCY9J3Z8",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Gruber and Meadows",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Gruber, Ethan, and Andrew Meadows. &#x201C;Numismatics and Linked Open Data.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 6, 2021, http://hdl.handle.net/2333.1/q83bkdqf.</div>\n</div>",
+        "citation": "<span>(Gruber and Meadows)</span>",
+        "data": {
+            "key": "NCY9J3Z8",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Numismatics and Linked Open Data",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Ethan",
+                    "lastName": "Gruber"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Andrew",
+                    "lastName": "Meadows"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "6",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/q83bkdqf",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T14:47:47Z",
+            "dateModified": "2021-12-11T11:49:38Z"
+        }
+    },
+    {
+        "key": "Z62YABCG",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/Z62YABCG",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/Z62YABCG",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Heath",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Heath, Sebastian. &#x201C;Applied Use of JSON, GeoJSON, JSON-LD, SPARQL, and IPython Notebooks for Representing and Interacting with Small Datasets.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Sarah E. Bond et al., vol. 20, no. 13, 2021, http://hdl.handle.net/2333.1/t1g1k70v.</div>\n</div>",
+        "citation": "<span>(Heath)</span>",
+        "data": {
+            "key": "Z62YABCG",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Applied Use of JSON, GeoJSON, JSON-LD, SPARQL, and IPython Notebooks for Representing and Interacting with Small Datasets",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Sebastian",
+                    "lastName": "Heath"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Sarah E.",
+                    "lastName": "Bond"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "This paper describes the role of standards-based and open source file formats and tools in representing and interacting with small datasets. The example used is a database of Roman amphitheaters that is based on the GeoJSON variant of JSON, both of which formats are briefly defined and explained by example. It is stressed that the code sharing site GitHub can map the spatial information in GeoJSON files by default. Next, a series of iPython notebooks - all of which can be run interactively or downloaded for further developemnt - show the implementation of a lightweight interface for exploring amphitheater seating capacity. In conclusion, the paper emphasizes that using existing tools can make it easier to maintain focus on the intellectual content of a dataset.",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "13",
+            "pages": "",
+            "date": "2021",
+            "series": "",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/t1g1k70v",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "All rights reserved",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T14:46:17Z",
+            "dateModified": "2021-12-11T11:49:38Z"
+        }
+    },
+    {
+        "key": "97YJDQ8J",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/97YJDQ8J",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/97YJDQ8J",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Babeu and Dilley",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Babeu, Alison, and Paul Dilley. &#x201C;Linked Open Data for Greek and Latin Authors and Works.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 9, 2021, http://hdl.handle.net/2333.1/b2rbp8wh.</div>\n</div>",
+        "citation": "<span>(Babeu and Dilley)</span>",
+        "data": {
+            "key": "97YJDQ8J",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data for Greek and Latin Authors and Works",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Alison",
+                    "lastName": "Babeu"
+                },
+                {
+                    "creatorType": "author",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "9",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/b2rbp8wh",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T15:03:31Z",
+            "dateModified": "2021-12-11T11:49:37Z"
+        }
+    },
+    {
+        "key": "WPNFRCKM",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/WPNFRCKM",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/WPNFRCKM",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Liuzzo",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Liuzzo, Pietro Maria. &#x201C;Linked Open Data Based on La Syntaxe Du Codex for Manuscripts in Beta Ma&#x1E63;&#x101;&#x1E25;&#x1DD;ft.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 7, 2021, http://hdl.handle.net/2333.1/kh189d69.</div>\n</div>",
+        "citation": "<span>(Liuzzo)</span>",
+        "data": {
+            "key": "WPNFRCKM",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Linked Open Data Based on La Syntaxe du Codex for Manuscripts in Beta maṣāḥǝft",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "Pietro Maria",
+                    "lastName": "Liuzzo"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "7",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/kh189d69",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {},
+            "dateAdded": "2021-04-15T14:54:15Z",
+            "dateModified": "2021-12-11T11:49:37Z"
+        }
+    },
+    {
+        "key": "VUNJPPMK",
+        "version": 527,
+        "library": {
+            "type": "group",
+            "id": 242005,
+            "name": "ISAW Papers",
+            "links": {
+                "alternate": {
+                    "href": "https://www.zotero.org/groups/isaw_papers",
+                    "type": "text/html"
+                }
+            }
+        },
+        "links": {
+            "self": {
+                "href": "https://api.zotero.org/groups/242005/items/VUNJPPMK",
+                "type": "application/json"
+            },
+            "alternate": {
+                "href": "https://www.zotero.org/groups/isaw_papers/items/VUNJPPMK",
+                "type": "text/html"
+            }
+        },
+        "meta": {
+            "createdByUser": {
+                "id": 50458,
+                "username": "sebastianheath",
+                "name": "Sebastian Heath",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/sebastianheath",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "lastModifiedByUser": {
+                "id": 465,
+                "username": "paregorios",
+                "name": "Tom Elliott",
+                "links": {
+                    "alternate": {
+                        "href": "https://www.zotero.org/paregorios",
+                        "type": "text/html"
+                    }
+                }
+            },
+            "creatorSummary": "Michelson",
+            "parsedDate": "2021",
+            "numChildren": 0
+        },
+        "bib": "<div class=\"csl-bib-body\" style=\"line-height: 2; padding-left: 1em; text-indent:-1em;\">\n  <div class=\"csl-entry\">Michelson, David. &#x201C;Using Linked Open Data to Model Cultural Heritage Information: The Research Questions and Data Structures of the Syriaca.Org Knowledge Graph.&#x201D; <i>Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects</i>, edited by Bond E. Sarah et al., vol. 20, no. 10, 2021, http://hdl.handle.net/2333.1/69p8d8cc.</div>\n</div>",
+        "citation": "<span>(Michelson)</span>",
+        "data": {
+            "key": "VUNJPPMK",
+            "version": 527,
+            "itemType": "journalArticle",
+            "title": "Using Linked Open Data to Model Cultural Heritage Information: The Research Questions and Data Structures of the Syriaca.org Knowledge Graph",
+            "creators": [
+                {
+                    "creatorType": "author",
+                    "firstName": "David",
+                    "lastName": "Michelson"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Bond E.",
+                    "lastName": "Sarah"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Paul",
+                    "lastName": "Dilley"
+                },
+                {
+                    "creatorType": "editor",
+                    "firstName": "Ryan",
+                    "lastName": "Horne"
+                }
+            ],
+            "abstractNote": "",
+            "publicationTitle": "Linked Open Data for the Ancient Mediterranean: Structures, Practices, Prospects",
+            "volume": "20",
+            "issue": "10",
+            "pages": "",
+            "date": "2021",
+            "series": "ISAW Papers",
+            "seriesTitle": "",
+            "seriesText": "",
+            "journalAbbreviation": "",
+            "language": "",
+            "DOI": "",
+            "ISSN": "",
+            "shortTitle": "",
+            "url": "http://hdl.handle.net/2333.1/69p8d8cc",
+            "accessDate": "",
+            "archive": "",
+            "archiveLocation": "",
+            "libraryCatalog": "",
+            "callNumber": "",
+            "rights": "",
+            "extra": "",
+            "tags": [
+                {
+                    "tag": "⛔ No DOI found",
+                    "type": 1
+                }
+            ],
+            "collections": [
+                "G3A4WDJS",
+                "XDRRSGM6"
+            ],
+            "relations": {
+                "dc:relation": "http://zotero.org/groups/242005/items/ETX9Q8VE"
+            },
+            "dateAdded": "2021-04-15T15:05:21Z",
+            "dateModified": "2021-12-11T11:49:36Z"
+        }
+    }
+]

--- a/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.url
+++ b/src/jazkarta/zoterolib/tests/data/8b1dcf09402f085f4839192d72bc8e2c96463fccd912f89e49714f683c1ba253.url
@@ -1,0 +1,1 @@
+https://api.zotero.org/groups/242005/items?sort=dateModified&style=modern-language-association&format=json&start=0&limit=100&include=data%2Cbib%2Ccitation

--- a/src/jazkarta/zoterolib/tests/mock_data.py
+++ b/src/jazkarta/zoterolib/tests/mock_data.py
@@ -1,0 +1,75 @@
+"""
+The contents of this file were filled up by enabling `real_http` in the mocks by
+setting the `REAL_HTTP` environment variable:
+
+export REAL_HTTP=true
+
+The http requests will be saved in the data folder to be replayed later.
+"""
+from hashlib import sha256
+import json
+import os
+import requests
+import requests.api
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+REAL_HTTP = bool(os.environ.get("REAL_HTTP"))
+
+
+def alternative_get(url, params=None, **kwargs):
+    result = requests.api.request('get', url, params=params, **kwargs)
+    save_data(result, url)
+    return result
+
+
+if REAL_HTTP:
+    requests.api.get = requests.get = alternative_get
+RESPONSES_MAP = {}
+
+for filename in os.listdir(DATA_DIR):
+    if not filename.endswith(".txt"):
+        continue
+    hash = filename[:-4]
+    url = (
+        open(os.path.join(os.path.dirname(__file__), "data", "%s.url" % hash))
+        .read()
+        .decode("utf-8")
+    )
+    body = (
+        open(os.path.join(os.path.dirname(__file__), "data", "%s.txt" % hash))
+        .read()
+        .decode("utf-8")
+    )
+    headers_txt = (
+        open(os.path.join(os.path.dirname(__file__), "data", "%s.headers.json" % hash))
+        .read()
+        .decode("utf-8")
+    )
+    headers = json.loads(headers_txt)
+    RESPONSES_MAP[hash] = {
+        "url": url,
+        "body": body,
+        "headers": headers,
+    }
+
+
+def fill_mocker(mock):
+    for info in RESPONSES_MAP.values():
+        mock.register_uri(
+            "GET", info["url"], text=info["body"], headers=info["headers"]
+        )
+
+
+def save_data(result, url):
+    """Function to save a response to a json and header file"""
+    hash = get_hash(url)
+    open(os.path.join(DATA_DIR, hash + '.txt'), 'w').write(result.text.encode("utf-8"))
+    headers = dict(result.headers)
+    if "Content-Encoding" in headers:
+        del headers["Content-Encoding"]
+    open(os.path.join(DATA_DIR, hash + '.headers.json'), 'w').write(json.dumps(headers))
+    open(os.path.join(DATA_DIR, hash + '.url'), 'w').write(url)
+
+
+def get_hash(url):
+    return sha256(url.encode("utf-8")).hexdigest()

--- a/src/jazkarta/zoterolib/tests/mock_data.py
+++ b/src/jazkarta/zoterolib/tests/mock_data.py
@@ -9,6 +9,7 @@ The http requests will be saved in the data folder to be replayed later.
 from hashlib import sha256
 import json
 import os
+import sys
 import requests
 import requests.api
 
@@ -26,24 +27,24 @@ if REAL_HTTP:
     requests.api.get = requests.get = alternative_get
 RESPONSES_MAP = {}
 
+
+def read_file(path):
+    if sys.version_info.major < 3:
+        with open(path, "r") as f:
+            return f.read().decode("utf-8")
+    else:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+
 for filename in os.listdir(DATA_DIR):
     if not filename.endswith(".txt"):
         continue
     hash = filename[:-4]
-    url = (
-        open(os.path.join(os.path.dirname(__file__), "data", "%s.url" % hash))
-        .read()
-        .decode("utf-8")
-    )
-    body = (
-        open(os.path.join(os.path.dirname(__file__), "data", "%s.txt" % hash))
-        .read()
-        .decode("utf-8")
-    )
-    headers_txt = (
-        open(os.path.join(os.path.dirname(__file__), "data", "%s.headers.json" % hash))
-        .read()
-        .decode("utf-8")
+    url = read_file(os.path.join(os.path.dirname(__file__), "data", "%s.url" % hash))
+    body = read_file(os.path.join(os.path.dirname(__file__), "data", "%s.txt" % hash))
+    headers_txt = read_file(
+        os.path.join(os.path.dirname(__file__), "data", "%s.headers.json" % hash)
     )
     headers = json.loads(headers_txt)
     RESPONSES_MAP[hash] = {

--- a/src/jazkarta/zoterolib/tests/test_ct_zotero_library.py
+++ b/src/jazkarta/zoterolib/tests/test_ct_zotero_library.py
@@ -143,6 +143,24 @@ class ZoteroLibraryIndexTest(unittest.TestCase):
             ),
         )
 
+    def test_update_items(self):
+        self.obj.fetch_and_index_items()
+        self.assertEqual(
+            len(self.catalog.searchResults(portal_type="ExternalZoteroItem")), 180
+        )
+        # Simulate new items on Zotero by removing the ones with most recent modification time
+        to_delete = self.catalog.searchResults(
+            sort_on='modified', portal_type="ExternalZoteroItem"
+        )[-10:]
+        for brain in to_delete:
+            self.catalog.uncatalog_object(brain.getPath())
+        self.assertEqual(
+            len(self.catalog.searchResults(portal_type="ExternalZoteroItem")), 170
+        )
+        self.obj.update_items()
+        results = self.catalog.searchResults(portal_type="ExternalZoteroItem")
+        self.assertEqual(len(results), 180)
+
     def validate_example_item(self, item):
         self.assertEqual(item.portal_type, "ExternalZoteroItem")
         self.assertEqual(item.Type, "Journal Article Reference")

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -33,3 +33,6 @@ anyjson = 0.3.3
 billiard = 3.3.0.23
 celery = 3.1.26.post2
 kombu = 3.0.37
+
+# Added by buildout at 2022-06-15 17:01:14.080461
+requests-mock = 1.9.3

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -36,3 +36,6 @@ kombu = 3.0.37
 
 # Added by buildout at 2022-06-15 17:01:14.080461
 requests-mock = 1.9.3
+
+# Added by buildout at 2022-06-15 22:13:40.060613
+zipp = 1.2.0


### PR DESCRIPTION
This PR adds the ability to run a partial update: first the date when the most recently modified object was modified is retrieved; then items from Zotero are fetched most-recently-modified first, and the update stops when an object is reached whose modification date is earlier than the most recent one gathered in the previous step.
It also includes mocking for zotero calls during tests: no actual API call will go out during test runs.
A primitive way to update the test files is also included.